### PR TITLE
Remove rust toolchain action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,12 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo clippy
@@ -32,12 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo fmt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Rust
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo clippy
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Rust
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo fmt


### PR DESCRIPTION
The Rust toolchain action is no longer supported and throwing warnings so removing and installing rust without the action.