### PR TITLE
Handle potential panic when validating file type

### DIFF
--- a/crates/prelude-parser-py/src/errors.rs
+++ b/crates/prelude-parser-py/src/errors.rs
@@ -11,6 +11,9 @@ pub enum XmlFileValidationError {
 
     #[error("{0:?} is not an xml file")]
     InvalidFileType(PathBuf),
+
+    #[error("No file extension found in {0:?}")]
+    NoFileExtension(PathBuf),
 }
 
 create_exception!(_prelude_parser, FileNotFoundError, PyException);

--- a/crates/prelude-parser-py/src/lib.rs
+++ b/crates/prelude-parser-py/src/lib.rs
@@ -40,6 +40,11 @@ fn check_valid_file(xml_file: &PathBuf) -> PyResult<()> {
                     "{xml_file:?} is not an xml file"
                 )))
             }
+            XmlFileValidationError::NoFileExtension(_) => {
+                return Err(InvalidFileTypeError::new_err(
+                    "No file extension found in file: {xml_file:?}",
+                ))
+            }
         };
     };
 

--- a/crates/prelude-parser-py/src/utils.rs
+++ b/crates/prelude-parser-py/src/utils.rs
@@ -23,8 +23,14 @@ pub fn to_snake(camel_string: &str) -> String {
 pub fn validate_file(xml_file: &PathBuf) -> Result<(), XmlFileValidationError> {
     if !xml_file.is_file() {
         return Err(XmlFileValidationError::FileNotFound(xml_file.to_owned()));
-    } else if xml_file.extension().unwrap() != "xml" {
-        return Err(XmlFileValidationError::InvalidFileType(xml_file.to_owned()));
+    }
+
+    if let Some(extension) = xml_file.extension() {
+        if extension != "xml" {
+            return Err(XmlFileValidationError::InvalidFileType(xml_file.to_owned()));
+        }
+    } else {
+        return Err(XmlFileValidationError::NoFileExtension(xml_file.to_owned()));
     }
 
     Ok(())


### PR DESCRIPTION
Previously unwrap was used, now the propper error is returned without panicing