### PR TITLE
Deserilization performance improvements

### DIFF
--- a/crates/prelude-xml-parser/src/lib.rs
+++ b/crates/prelude-xml-parser/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod errors;
 pub mod native;
 
-use std::{borrow::Cow, collections::HashMap, fs::read_to_string, path::Path, str::from_utf8};
+use std::{fs::read_to_string, path::Path};
 
 use rayon::prelude::*;
 
@@ -12,7 +12,7 @@ use crate::native::{
     subject_native::{Form, Patient, SubjectNative},
     user_native::{User, UserNative},
 };
-use quick_xml::events::{BytesStart, Event};
+use quick_xml::events::Event;
 use quick_xml::Reader;
 
 /// Parses a Prelude native XML file into a `Native` struct.
@@ -662,30 +662,6 @@ pub fn parse_subject_native_string(xml_str: &str) -> Result<SubjectNative, Error
     Ok(SubjectNative { patients })
 }
 
-fn extract_attributes<'a>(e: &'a BytesStart<'a>) -> Result<HashMap<&'a str, &'a str>, Error> {
-    let mut attrs = HashMap::new();
-    for attr in e.attributes() {
-        let attr = attr.map_err(|e| {
-            Error::ParsingError(quick_xml::de::DeError::Custom(format!(
-                "Attribute error: {}",
-                e
-            )))
-        })?;
-        let Cow::Borrowed(value) = attr.value else {
-            return Err(Error::ParsingError(quick_xml::de::DeError::Custom(
-                "Attribute value was not borrowed from the source".to_string(),
-            )));
-        };
-        let (Ok(key), Ok(value)) = (from_utf8(attr.key.into_inner()), from_utf8(value)) else {
-            return Err(Error::ParsingError(quick_xml::de::DeError::Custom(
-                "Attribute was not valid UTF-8".to_string(),
-            )));
-        };
-        attrs.insert(key, value);
-    }
-    Ok(attrs)
-}
-
 fn extract_patient_chunks(xml: &str) -> Vec<&str> {
     let mut chunks = Vec::new();
     let mut pos = 0;
@@ -749,53 +725,41 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "patient" => {
-                            let attrs = extract_attributes(e)?;
-                            current_patient = Some(Patient::from_attributes(attrs)?);
+                            current_patient = Some(Patient::from_attributes(e)?);
                             current_forms.clear();
                         }
                         "form" if current_patient.is_some() => {
-                            let attrs = extract_attributes(e)?;
-                            current_form = Some(Form::from_attributes(attrs)?);
+                            current_form = Some(Form::from_attributes(e)?);
                             in_form = true;
                             current_states.clear();
                             current_categories.clear();
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_category = Some(Category::from_attributes(attrs)?);
+                            current_category = Some(Category::from_attributes(e)?);
                             in_category = true;
                             current_fields.clear();
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            current_field = Some(Field::from_attributes(attrs)?);
+                            current_field = Some(Field::from_attributes(e)?);
                             in_field = true;
                             current_entries.clear();
                             current_comments.clear();
                         }
                         "entry" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            current_entry = Some(Entry::from_attributes(attrs)?);
+                            current_entry = Some(Entry::from_attributes(e)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            let comment_id = attrs.get("id").cloned().unwrap_or_default();
-                            current_comment = Some(Comment {
-                                comment_id: comment_id.to_string(),
-                                value: None,
-                            });
+                            current_comment = Some(Comment::from_attributes(e)?);
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            let attrs = extract_attributes(e)?;
-                            current_value = Some(Value::from_attributes(attrs)?);
+                            current_value = Some(Value::from_attributes(e)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            current_reason = Some(Reason::from_attributes(attrs)?);
+                            current_reason = Some(Reason::from_attributes(e)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -895,35 +859,29 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            let state = State::from_attributes(attrs)?;
+                            let state = State::from_attributes(e)?;
                             current_states.push(state);
                         }
                         "lockState" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            let lock_state = LockState::from_attributes(attrs)?;
+                            let lock_state = LockState::from_attributes(e)?;
                             if let Some(ref mut form) = current_form {
                                 form.lock_state = Some(lock_state);
                             }
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_categories.push(Category::from_attributes(attrs)?);
+                            current_categories.push(Category::from_attributes(e)?);
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            current_fields.push(Field::from_attributes(attrs)?);
+                            current_fields.push(Field::from_attributes(e)?);
                         }
                         "value" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            let value = Value::from_attributes(attrs)?;
+                            let value = Value::from_attributes(e)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.value = Some(value);
                             }
                         }
                         "reason" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            let reason = Reason::from_attributes(attrs)?;
+                            let reason = Reason::from_attributes(e)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.reason = Some(reason);
                             }
@@ -1007,53 +965,41 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "site" => {
-                            let attrs = extract_attributes(e)?;
-                            current_site = Some(Site::from_attributes(attrs)?);
+                            current_site = Some(Site::from_attributes(e)?);
                             current_forms.clear();
                         }
                         "form" if current_site.is_some() => {
-                            let attrs = extract_attributes(e)?;
-                            current_form = Some(Form::from_attributes(attrs)?);
+                            current_form = Some(Form::from_attributes(e)?);
                             in_form = true;
                             current_states.clear();
                             current_categories.clear();
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_category = Some(Category::from_attributes(attrs)?);
+                            current_category = Some(Category::from_attributes(e)?);
                             in_category = true;
                             current_fields.clear();
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            current_field = Some(Field::from_attributes(attrs)?);
+                            current_field = Some(Field::from_attributes(e)?);
                             in_field = true;
                             current_entries.clear();
                             current_comments.clear();
                         }
                         "entry" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            current_entry = Some(Entry::from_attributes(attrs)?);
+                            current_entry = Some(Entry::from_attributes(e)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            let comment_id = attrs.get("id").cloned().unwrap_or_default();
-                            current_comment = Some(Comment {
-                                comment_id: comment_id.to_string(),
-                                value: None,
-                            });
+                            current_comment = Some(Comment::from_attributes(e)?);
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            let attrs = extract_attributes(e)?;
-                            current_value = Some(Value::from_attributes(attrs)?);
+                            current_value = Some(Value::from_attributes(e)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            current_reason = Some(Reason::from_attributes(attrs)?);
+                            current_reason = Some(Reason::from_attributes(e)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -1153,36 +1099,30 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            let state = State::from_attributes(attrs)?;
+                            let state = State::from_attributes(e)?;
                             current_states.push(state);
                         }
                         "lockState" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            let lock_state = LockState::from_attributes(attrs)?;
+                            let lock_state = LockState::from_attributes(e)?;
                             if let Some(ref mut form) = current_form {
                                 form.lock_state = Some(lock_state);
                             }
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_categories.push(Category::from_attributes(attrs)?);
+                            current_categories.push(Category::from_attributes(e)?);
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            let field = Field::from_attributes(attrs)?;
+                            let field = Field::from_attributes(e)?;
                             current_fields.push(field);
                         }
                         "value" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            let value = Value::from_attributes(attrs)?;
+                            let value = Value::from_attributes(e)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.value = Some(value);
                             }
                         }
                         "reason" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            let reason = Reason::from_attributes(attrs)?;
+                            let reason = Reason::from_attributes(e)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.reason = Some(reason);
                             }
@@ -1469,47 +1409,35 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "user" => {
-                            let attrs = extract_attributes(e)?;
-                            current_user = Some(User::from_attributes(attrs)?);
+                            current_user = Some(User::from_attributes(e)?);
                         }
                         "form" => {
-                            let attrs = extract_attributes(e)?;
-                            current_form = Some(Form::from_attributes(attrs)?);
+                            current_form = Some(Form::from_attributes(e)?);
                             in_form = true;
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_category = Some(Category::from_attributes(attrs)?);
+                            current_category = Some(Category::from_attributes(e)?);
                             in_category = true;
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            current_field = Some(Field::from_attributes(attrs)?);
+                            current_field = Some(Field::from_attributes(e)?);
                             in_field = true;
                         }
                         "entry" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            current_entry = Some(Entry::from_attributes(attrs)?);
+                            current_entry = Some(Entry::from_attributes(e)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
-                            let attrs = extract_attributes(e)?;
-                            let comment_id = attrs.get("id").cloned().unwrap_or_default();
-                            current_comment = Some(Comment {
-                                comment_id: comment_id.to_string(),
-                                value: None,
-                            });
+                            current_comment = Some(Comment::from_attributes(e)?);
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            let attrs = extract_attributes(e)?;
-                            current_value = Some(Value::from_attributes(attrs)?);
+                            current_value = Some(Value::from_attributes(e)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            let attrs = extract_attributes(e)?;
-                            current_reason = Some(Reason::from_attributes(attrs)?);
+                            current_reason = Some(Reason::from_attributes(e)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -1609,17 +1537,14 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            let state = State::from_attributes(attrs)?;
+                            let state = State::from_attributes(e)?;
                             current_states.push(state);
                         }
                         "category" if in_form => {
-                            let attrs = extract_attributes(e)?;
-                            current_categories.push(Category::from_attributes(attrs)?);
+                            current_categories.push(Category::from_attributes(e)?);
                         }
                         "field" if in_category => {
-                            let attrs = extract_attributes(e)?;
-                            let field = Field::from_attributes(attrs)?;
+                            let field = Field::from_attributes(e)?;
                             current_fields.push(field);
                         }
                         _ => {}

--- a/crates/prelude-xml-parser/src/native/common.rs
+++ b/crates/prelude-xml-parser/src/native/common.rs
@@ -7,9 +7,12 @@ use pyo3::{
     types::{PyDateTime, PyDict},
 };
 
+use quick_xml::events::BytesStart;
+
 use crate::native::deserializers::{
-    default_datetime_none, default_string_none, deserialize_empty_string_as_none,
-    deserialize_empty_string_as_none_datetime, parse_datetime,
+    checked_datetime, default_datetime_none, default_string_none, deserialize_empty_string_as_none,
+    deserialize_empty_string_as_none_datetime, optional_datetime, optional_string,
+    visit_attributes,
 };
 
 #[cfg(feature = "python")]
@@ -675,107 +678,60 @@ impl Category {
 }
 
 impl Form {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let name = attrs.get("name").copied().unwrap_or_default().to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut name = "";
+        let mut last_modified = "";
+        let mut who_last_modified_name = "";
+        let mut who_last_modified_role = "";
+        let mut when_created = "";
+        let mut has_errors = "";
+        let mut has_warnings = "";
+        let mut locked = "";
+        let mut user = "";
+        let mut date_time_changed = "";
+        let mut form_title = "";
+        let mut form_index = "";
+        let mut form_group = "";
+        let mut form_state = "";
 
-        let last_modified = if let Some(lm) = attrs.get("lastModified") {
-            if lm.is_empty() {
-                None
-            } else {
-                parse_datetime_internal(lm).ok()
-            }
-        } else {
-            None
-        };
-
-        let who_last_modified_name = attrs
-            .get("whoLastModifiedName")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let who_last_modified_role = attrs
-            .get("whoLastModifiedRole")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let when_created = attrs
-            .get("whenCreated")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let has_errors = attrs
-            .get("hasErrors")
-            .map(|s| *s == "true")
-            .unwrap_or(false);
-
-        let has_warnings = attrs
-            .get("hasWarnings")
-            .map(|s| *s == "true")
-            .unwrap_or(false);
-
-        let locked = attrs.get("locked").map(|s| *s == "true").unwrap_or(false);
-
-        let user = attrs
-            .get("user")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let date_time_changed = if let Some(dtc) = attrs.get("dateTimeChanged") {
-            if dtc.is_empty() {
-                None
-            } else {
-                parse_datetime_internal(dtc).ok()
-            }
-        } else {
-            None
-        };
-
-        let form_title = attrs
-            .get("formTitle")
-            .copied()
-            .unwrap_or_default()
-            .to_string();
-
-        let form_index = attrs
-            .get("formIndex")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let form_group = attrs
-            .get("formGroup")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let form_state = attrs
-            .get("formState")
-            .copied()
-            .unwrap_or_default()
-            .to_string();
+        visit_attributes(e, |key, attr| match key {
+            b"name" => name = attr,
+            b"lastModified" => last_modified = attr,
+            b"whoLastModifiedName" => who_last_modified_name = attr,
+            b"whoLastModifiedRole" => who_last_modified_role = attr,
+            b"whenCreated" => when_created = attr,
+            b"hasErrors" => has_errors = attr,
+            b"hasWarnings" => has_warnings = attr,
+            b"locked" => locked = attr,
+            b"user" => user = attr,
+            b"dateTimeChanged" => date_time_changed = attr,
+            b"formTitle" => form_title = attr,
+            b"formIndex" => form_index = attr,
+            b"formGroup" => form_group = attr,
+            b"formState" => form_state = attr,
+            _ => {}
+        })?;
 
         Ok(Form {
-            name,
-            last_modified,
-            who_last_modified_name,
-            who_last_modified_role,
-            when_created,
-            has_errors,
-            has_warnings,
-            locked,
-            user,
-            date_time_changed,
-            form_title,
-            form_index,
-            form_group,
-            form_state,
+            name: name.to_string(),
+            last_modified: optional_datetime(last_modified),
+            who_last_modified_name: optional_string(who_last_modified_name),
+            who_last_modified_role: optional_string(who_last_modified_role),
+            when_created: when_created.parse().unwrap_or(0),
+            has_errors: has_errors == "true",
+            has_warnings: has_warnings == "true",
+            locked: locked == "true",
+            user: optional_string(user),
+            date_time_changed: optional_datetime(date_time_changed),
+            form_title: form_title.to_string(),
+            form_index: form_index.parse().unwrap_or(0),
+            form_group: optional_string(form_group),
+            form_state: form_state.to_string(),
             states: None,
             lock_state: None,
             categories: None,
         })
     }
-}
-
-fn parse_datetime_internal(s: &str) -> Result<DateTime<Utc>, crate::errors::Error> {
-    parse_datetime(s)
 }
 
 #[cfg(not(feature = "python"))]
@@ -1326,127 +1282,101 @@ impl Form {
 }
 
 impl State {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let value = attrs.get("value").copied().unwrap_or_default().to_string();
-        let signer = attrs.get("signer").copied().unwrap_or_default().to_string();
-        let signer_unique_id = attrs
-            .get("signerUniqueId")
-            .copied()
-            .unwrap_or_default()
-            .to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut value = "";
+        let mut signer = "";
+        let mut signer_unique_id = "";
+        let mut date_signed = "";
 
-        let date_signed = if let Some(ds) = attrs.get("dateSigned") {
-            if ds.is_empty() {
-                None
-            } else {
-                parse_datetime_internal(ds).ok()
-            }
-        } else {
-            None
-        };
+        visit_attributes(e, |key, attr| match key {
+            b"value" => value = attr,
+            b"signer" => signer = attr,
+            b"signerUniqueId" => signer_unique_id = attr,
+            b"dateSigned" => date_signed = attr,
+            _ => {}
+        })?;
 
         Ok(State {
-            value,
-            signer,
-            signer_unique_id,
-            date_signed,
+            value: value.to_string(),
+            signer: signer.to_string(),
+            signer_unique_id: signer_unique_id.to_string(),
+            date_signed: optional_datetime(date_signed),
         })
     }
 }
 
 impl LockState {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let locked = attrs.get("locked").map(|s| *s == "true").unwrap_or(false);
-        let user = attrs
-            .get("user")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let user_unique_id = attrs
-            .get("userUniqueId")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut locked = "";
+        let mut user = "";
+        let mut user_unique_id = "";
+        let mut date_time_changed = "";
 
-        let date_time_changed = if let Some(dtc) = attrs.get("dateTimeChanged") {
-            if dtc.is_empty() {
-                None
-            } else {
-                parse_datetime_internal(dtc).ok()
-            }
-        } else {
-            None
-        };
+        visit_attributes(e, |key, attr| match key {
+            b"locked" => locked = attr,
+            b"user" => user = attr,
+            b"userUniqueId" => user_unique_id = attr,
+            b"dateTimeChanged" => date_time_changed = attr,
+            _ => {}
+        })?;
 
         Ok(LockState {
-            locked,
-            user,
-            user_unique_id,
-            date_time_changed,
+            locked: locked == "true",
+            user: optional_string(user),
+            user_unique_id: optional_string(user_unique_id),
+            date_time_changed: optional_datetime(date_time_changed),
         })
     }
 }
 
 impl Category {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let name = attrs.get("name").copied().unwrap_or_default().to_string();
-        let category_type = attrs.get("type").copied().unwrap_or_default().to_string();
-        let highest_index = attrs
-            .get("highestIndex")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut name = "";
+        let mut category_type = "";
+        let mut highest_index = "";
+
+        visit_attributes(e, |key, attr| match key {
+            b"name" => name = attr,
+            b"type" => category_type = attr,
+            b"highestIndex" => highest_index = attr,
+            _ => {}
+        })?;
 
         Ok(Category {
-            name,
-            category_type,
-            highest_index,
+            name: name.to_string(),
+            category_type: category_type.to_string(),
+            highest_index: highest_index.parse().unwrap_or(0),
             fields: None,
         })
     }
 }
 
 impl Field {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let name = attrs.get("name").copied().unwrap_or_default().to_string();
-        let field_type = attrs.get("type").copied().unwrap_or_default().to_string();
-        let data_type = attrs
-            .get("dataType")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let error_code = attrs
-            .get("errorCode")
-            .copied()
-            .unwrap_or_default()
-            .to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut name = "";
+        let mut field_type = "";
+        let mut data_type = "";
+        let mut error_code = "";
+        let mut when_created = "";
+        let mut keep_history = "";
 
-        let when_created = if let Some(wc) = attrs.get("whenCreated") {
-            if wc.is_empty() {
-                None
-            } else {
-                Some(parse_datetime_internal(wc)?)
-            }
-        } else {
-            None
-        };
-
-        let keep_history = attrs
-            .get("keepHistory")
-            .map(|s| *s == "true")
-            .unwrap_or(false);
+        visit_attributes(e, |key, attr| match key {
+            b"name" => name = attr,
+            b"type" => field_type = attr,
+            b"dataType" => data_type = attr,
+            b"errorCode" => error_code = attr,
+            b"whenCreated" => when_created = attr,
+            b"keepHistory" => keep_history = attr,
+            _ => {}
+        })?;
 
         Ok(Field {
-            name,
-            field_type,
-            data_type,
-            error_code,
-            when_created,
-            keep_history,
+            name: name.to_string(),
+            field_type: field_type.to_string(),
+            data_type: optional_string(data_type),
+            error_code: error_code.to_string(),
+            when_created: checked_datetime(when_created)?,
+            keep_history: keep_history == "true",
             entries: None,
             comments: None,
         })
@@ -1454,40 +1384,27 @@ impl Field {
 }
 
 impl Entry {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let entry_id = attrs
-            .get("id")
-            .or_else(|| attrs.get("entryId"))
-            .copied()
-            .unwrap_or_default()
-            .to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut id: Option<&str> = None;
+        let mut entry_id: Option<&str> = None;
+        let mut reviewed_by = "";
+        let mut reviewed_by_unique_id = "";
+        let mut reviewed_by_when = "";
 
-        let reviewed_by = attrs
-            .get("reviewedBy")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let reviewed_by_unique_id = attrs
-            .get("reviewedByUniqueId")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let reviewed_by_when = if let Some(rbw) = attrs.get("reviewedByWhen") {
-            if rbw.is_empty() {
-                None
-            } else {
-                parse_datetime_internal(rbw).ok()
-            }
-        } else {
-            None
-        };
+        visit_attributes(e, |key, attr| match key {
+            b"id" => id = Some(attr),
+            b"entryId" => entry_id = Some(attr),
+            b"reviewedBy" => reviewed_by = attr,
+            b"reviewedByUniqueId" => reviewed_by_unique_id = attr,
+            b"reviewedByWhen" => reviewed_by_when = attr,
+            _ => {}
+        })?;
 
         Ok(Entry {
-            entry_id,
-            reviewed_by,
-            reviewed_by_unique_id,
-            reviewed_by_when,
+            entry_id: id.or(entry_id).unwrap_or_default().to_string(),
+            reviewed_by: optional_string(reviewed_by),
+            reviewed_by_unique_id: optional_string(reviewed_by_unique_id),
+            reviewed_by_when: optional_datetime(reviewed_by_when),
             value: None,
             reason: None,
         })
@@ -1495,63 +1412,68 @@ impl Entry {
 }
 
 impl Value {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let by = attrs.get("by").copied().unwrap_or_default().to_string();
-        let by_unique_id = attrs
-            .get("byUniqueId")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let role = attrs.get("role").copied().unwrap_or_default().to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut by = "";
+        let mut by_unique_id = "";
+        let mut role = "";
+        let mut when = "";
 
-        let when = if let Some(w) = attrs.get("when") {
-            if w.is_empty() {
-                None
-            } else {
-                Some(parse_datetime_internal(w)?)
-            }
-        } else {
-            None
-        };
+        visit_attributes(e, |key, attr| match key {
+            b"by" => by = attr,
+            b"byUniqueId" => by_unique_id = attr,
+            b"role" => role = attr,
+            b"when" => when = attr,
+            _ => {}
+        })?;
 
         Ok(Value {
-            by,
-            by_unique_id,
-            role,
-            when,
+            by: by.to_string(),
+            by_unique_id: optional_string(by_unique_id),
+            role: role.to_string(),
+            when: checked_datetime(when)?,
             value: String::new(),
         })
     }
 }
 
 impl Reason {
-    pub(crate) fn from_attributes(
-        attrs: std::collections::HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let by = attrs.get("by").copied().unwrap_or_default().to_string();
-        let by_unique_id = attrs
-            .get("byUniqueId")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-        let role = attrs.get("role").copied().unwrap_or_default().to_string();
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut by = "";
+        let mut by_unique_id = "";
+        let mut role = "";
+        let mut when = "";
 
-        let when = if let Some(w) = attrs.get("when") {
-            if w.is_empty() {
-                None
-            } else {
-                Some(parse_datetime_internal(w)?)
-            }
-        } else {
-            None
-        };
+        visit_attributes(e, |key, attr| match key {
+            b"by" => by = attr,
+            b"byUniqueId" => by_unique_id = attr,
+            b"role" => role = attr,
+            b"when" => when = attr,
+            _ => {}
+        })?;
 
         Ok(Reason {
-            by,
-            by_unique_id,
-            role,
-            when,
+            by: by.to_string(),
+            by_unique_id: optional_string(by_unique_id),
+            role: role.to_string(),
+            when: checked_datetime(when)?,
             value: String::new(),
+        })
+    }
+}
+
+impl Comment {
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut comment_id = "";
+
+        visit_attributes(e, |key, attr| {
+            if key == b"id" {
+                comment_id = attr;
+            }
+        })?;
+
+        Ok(Comment {
+            comment_id: comment_id.to_string(),
+            value: None,
         })
     }
 }

--- a/crates/prelude-xml-parser/src/native/deserializers.rs
+++ b/crates/prelude-xml-parser/src/native/deserializers.rs
@@ -1,9 +1,91 @@
 #[cfg(feature = "python")]
 use chrono::{Datelike, Timelike};
 
+use std::borrow::Cow;
+use std::str::from_utf8;
+
 use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone, Utc};
 
+use quick_xml::events::BytesStart;
 use serde::{Deserialize, Deserializer};
+
+/// Walk an element's attributes once, handing each raw key and its borrowed value to `visit`.
+///
+/// Matching on the raw key bytes lets callers pull out the attributes they care about without
+/// building an intermediate map, which matters because this runs for every element in the file.
+pub(crate) fn visit_attributes<'a>(
+    e: &'a BytesStart<'a>,
+    mut visit: impl FnMut(&'a [u8], &'a str),
+) -> Result<(), crate::errors::Error> {
+    for attr in e.attributes() {
+        let attr = attr.map_err(|e| {
+            crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(format!(
+                "Attribute error: {}",
+                e
+            )))
+        })?;
+
+        let Cow::Borrowed(value) = attr.value else {
+            return Err(crate::errors::Error::ParsingError(
+                quick_xml::de::DeError::Custom(
+                    "Attribute value was not borrowed from the source".to_string(),
+                ),
+            ));
+        };
+
+        let Ok(value) = from_utf8(value) else {
+            return Err(crate::errors::Error::ParsingError(
+                quick_xml::de::DeError::Custom("Attribute was not valid UTF-8".to_string()),
+            ));
+        };
+
+        visit(attr.key.into_inner(), value);
+    }
+
+    Ok(())
+}
+
+/// Parse an attribute that carries a datetime, treating an empty string as absent and an
+/// unparsable value as absent.
+pub(crate) fn optional_datetime(s: &str) -> Option<DateTime<Utc>> {
+    if s.is_empty() {
+        None
+    } else {
+        parse_datetime(s).ok()
+    }
+}
+
+/// Parse an attribute that carries a datetime, treating an empty string as absent but reporting an
+/// unparsable value as an error.
+pub(crate) fn checked_datetime(s: &str) -> Result<Option<DateTime<Utc>>, crate::errors::Error> {
+    if s.is_empty() {
+        Ok(None)
+    } else {
+        parse_datetime(s).map(Some)
+    }
+}
+
+/// Take an attribute that must be present, reporting its absence as an error.
+pub(crate) fn required_attribute(
+    value: Option<&str>,
+    name: &str,
+) -> Result<String, crate::errors::Error> {
+    match value {
+        Some(value) => Ok(value.to_string()),
+        None => Err(crate::errors::Error::ParsingError(
+            quick_xml::de::DeError::Custom(format!("Missing {}", name)),
+        )),
+    }
+}
+
+/// Convert an attribute into an owned `String`, treating an empty string as absent.
+pub(crate) fn optional_string(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
 
 fn two_digits(tens: u8, ones: u8) -> Option<u32> {
     if !tens.is_ascii_digit() || !ones.is_ascii_digit() {

--- a/crates/prelude-xml-parser/src/native/site_native.rs
+++ b/crates/prelude-xml-parser/src/native/site_native.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "python")]
@@ -13,7 +11,9 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::native::common::{Category, Comment, Entry, Field, Form, Reason, State, Value};
 
-use crate::native::deserializers::parse_datetime;
+use quick_xml::events::BytesStart;
+
+use crate::native::deserializers::{checked_datetime, required_attribute, visit_attributes};
 
 #[cfg(feature = "python")]
 use crate::native::deserializers::to_py_datetime;
@@ -56,72 +56,34 @@ pub struct Site {
 
 #[cfg(not(feature = "python"))]
 impl Site {
-    pub(crate) fn from_attributes(
-        attrs: HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let name = attrs
-            .get("name")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing name".to_string(),
-                ))
-            })?;
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut name: Option<&str> = None;
+        let mut unique_id: Option<&str> = None;
+        let mut number_of_patients = "";
+        let mut count_of_randomized_patients = "";
+        let mut when_created = "";
+        let mut creator: Option<&str> = None;
+        let mut number_of_forms = "";
 
-        let unique_id = attrs
-            .get("uniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing uniqueId".to_string(),
-                ))
-            })?;
-
-        let number_of_patients = attrs
-            .get("numberOfPatients")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let count_of_randomized_patients = attrs
-            .get("countOfRandomizedPatients")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let when_created = if let Some(wc_str) = attrs.get("whenCreated") {
-            if wc_str.is_empty() {
-                None
-            } else {
-                Some(parse_datetime(wc_str)?)
-            }
-        } else {
-            None
-        };
-
-        let creator = attrs
-            .get("creator")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing creator".to_string(),
-                ))
-            })?;
-
-        let number_of_forms = attrs
-            .get("numberOfForms")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        visit_attributes(e, |key, attr| match key {
+            b"name" => name = Some(attr),
+            b"uniqueId" => unique_id = Some(attr),
+            b"numberOfPatients" => number_of_patients = attr,
+            b"countOfRandomizedPatients" => count_of_randomized_patients = attr,
+            b"whenCreated" => when_created = attr,
+            b"creator" => creator = Some(attr),
+            b"numberOfForms" => number_of_forms = attr,
+            _ => {}
+        })?;
 
         Ok(Site {
-            name,
-            unique_id,
-            number_of_patients,
-            count_of_randomized_patients,
-            when_created,
-            creator,
-            number_of_forms,
+            name: required_attribute(name, "name")?,
+            unique_id: required_attribute(unique_id, "uniqueId")?,
+            number_of_patients: number_of_patients.parse().unwrap_or(0),
+            count_of_randomized_patients: count_of_randomized_patients.parse().unwrap_or(0),
+            when_created: checked_datetime(when_created)?,
+            creator: required_attribute(creator, "creator")?,
+            number_of_forms: number_of_forms.parse().unwrap_or(0),
             forms: None,
         })
     }
@@ -170,72 +132,34 @@ pub struct Site {
 
 #[cfg(feature = "python")]
 impl Site {
-    pub(crate) fn from_attributes(
-        attrs: HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let name = attrs
-            .get("name")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing name".to_string(),
-                ))
-            })?;
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut name: Option<&str> = None;
+        let mut unique_id: Option<&str> = None;
+        let mut number_of_patients = "";
+        let mut count_of_randomized_patients = "";
+        let mut when_created = "";
+        let mut creator: Option<&str> = None;
+        let mut number_of_forms = "";
 
-        let unique_id = attrs
-            .get("uniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing uniqueId".to_string(),
-                ))
-            })?;
-
-        let number_of_patients = attrs
-            .get("numberOfPatients")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let count_of_randomized_patients = attrs
-            .get("countOfRandomizedPatients")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let when_created = if let Some(wc_str) = attrs.get("whenCreated") {
-            if wc_str.is_empty() {
-                None
-            } else {
-                Some(parse_datetime(wc_str)?)
-            }
-        } else {
-            None
-        };
-
-        let creator = attrs
-            .get("creator")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing creator".to_string(),
-                ))
-            })?;
-
-        let number_of_forms = attrs
-            .get("numberOfForms")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        visit_attributes(e, |key, attr| match key {
+            b"name" => name = Some(attr),
+            b"uniqueId" => unique_id = Some(attr),
+            b"numberOfPatients" => number_of_patients = attr,
+            b"countOfRandomizedPatients" => count_of_randomized_patients = attr,
+            b"whenCreated" => when_created = attr,
+            b"creator" => creator = Some(attr),
+            b"numberOfForms" => number_of_forms = attr,
+            _ => {}
+        })?;
 
         Ok(Site {
-            name,
-            unique_id,
-            number_of_patients,
-            count_of_randomized_patients,
-            when_created,
-            creator,
-            number_of_forms,
+            name: required_attribute(name, "name")?,
+            unique_id: required_attribute(unique_id, "uniqueId")?,
+            number_of_patients: number_of_patients.parse().unwrap_or(0),
+            count_of_randomized_patients: count_of_randomized_patients.parse().unwrap_or(0),
+            when_created: checked_datetime(when_created)?,
+            creator: required_attribute(creator, "creator")?,
+            number_of_forms: number_of_forms.parse().unwrap_or(0),
             forms: None,
         })
     }

--- a/crates/prelude-xml-parser/src/native/subject_native.rs
+++ b/crates/prelude-xml-parser/src/native/subject_native.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "python")]
@@ -9,7 +7,11 @@ use pyo3::{
     types::{PyDateTime, PyDict},
 };
 
-use crate::native::deserializers::parse_datetime;
+use quick_xml::events::BytesStart;
+
+use crate::native::deserializers::{
+    checked_datetime, optional_string, required_attribute, visit_attributes,
+};
 
 #[cfg(feature = "python")]
 use crate::native::deserializers::{
@@ -42,88 +44,37 @@ pub struct Patient {
 }
 
 impl Patient {
-    pub(crate) fn from_attributes(
-        attrs: HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let patient_id = attrs
-            .get("patientId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing patientId".to_string(),
-                ))
-            })?;
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut patient_id: Option<&str> = None;
+        let mut unique_id: Option<&str> = None;
+        let mut when_created = "";
+        let mut creator: Option<&str> = None;
+        let mut site_name: Option<&str> = None;
+        let mut site_unique_id: Option<&str> = None;
+        let mut last_language = "";
+        let mut number_of_forms = "";
 
-        let unique_id = attrs
-            .get("uniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing uniqueId".to_string(),
-                ))
-            })?;
-
-        let when_created = if let Some(wc_str) = attrs.get("whenCreated") {
-            if wc_str.is_empty() {
-                None
-            } else {
-                Some(parse_datetime(wc_str)?)
-            }
-        } else {
-            None
-        };
-
-        let creator = attrs
-            .get("creator")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing creator".to_string(),
-                ))
-            })?;
-
-        let site_name = attrs
-            .get("siteName")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing siteName".to_string(),
-                ))
-            })?;
-
-        let site_unique_id = attrs
-            .get("siteUniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing siteUniqueId".to_string(),
-                ))
-            })?;
-
-        let last_language = attrs
-            .get("lastLanguage")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let number_of_forms = attrs
-            .get("numberOfForms")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        visit_attributes(e, |key, attr| match key {
+            b"patientId" => patient_id = Some(attr),
+            b"uniqueId" => unique_id = Some(attr),
+            b"whenCreated" => when_created = attr,
+            b"creator" => creator = Some(attr),
+            b"siteName" => site_name = Some(attr),
+            b"siteUniqueId" => site_unique_id = Some(attr),
+            b"lastLanguage" => last_language = attr,
+            b"numberOfForms" => number_of_forms = attr,
+            _ => {}
+        })?;
 
         Ok(Patient {
-            patient_id,
-            unique_id,
-            when_created,
-            creator,
-            site_name,
-            site_unique_id,
-            last_language,
-            number_of_forms,
+            patient_id: required_attribute(patient_id, "patientId")?,
+            unique_id: required_attribute(unique_id, "uniqueId")?,
+            when_created: checked_datetime(when_created)?,
+            creator: required_attribute(creator, "creator")?,
+            site_name: required_attribute(site_name, "siteName")?,
+            site_unique_id: required_attribute(site_unique_id, "siteUniqueId")?,
+            last_language: optional_string(last_language),
+            number_of_forms: number_of_forms.parse().unwrap_or(0),
             forms: None,
         })
     }

--- a/crates/prelude-xml-parser/src/native/user_native.rs
+++ b/crates/prelude-xml-parser/src/native/user_native.rs
@@ -1,12 +1,15 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "python")]
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 
 pub use crate::native::common::{Category, Comment, Entry, Field, Form, Reason, State, Value};
-use crate::native::deserializers::{default_string_none, deserialize_empty_string_as_none};
+use quick_xml::events::BytesStart;
+
+use crate::native::deserializers::{
+    default_string_none, deserialize_empty_string_as_none, optional_string, required_attribute,
+    visit_attributes,
+};
 
 #[cfg(not(feature = "python"))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -40,44 +43,25 @@ pub struct User {
 
 #[cfg(not(feature = "python"))]
 impl User {
-    pub(crate) fn from_attributes(
-        attrs: HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let unique_id = attrs
-            .get("uniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing uniqueId".to_string(),
-                ))
-            })?;
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut unique_id: Option<&str> = None;
+        let mut last_language = "";
+        let mut creator: Option<&str> = None;
+        let mut number_of_forms = "";
 
-        let last_language = attrs
-            .get("lastLanguage")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let creator = attrs
-            .get("creator")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing creator".to_string(),
-                ))
-            })?;
-
-        let number_of_forms = attrs
-            .get("numberOfForms")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        visit_attributes(e, |key, attr| match key {
+            b"uniqueId" => unique_id = Some(attr),
+            b"lastLanguage" => last_language = attr,
+            b"creator" => creator = Some(attr),
+            b"numberOfForms" => number_of_forms = attr,
+            _ => {}
+        })?;
 
         Ok(User {
-            unique_id,
-            last_language,
-            creator,
-            number_of_forms,
+            unique_id: required_attribute(unique_id, "uniqueId")?,
+            last_language: optional_string(last_language),
+            creator: required_attribute(creator, "creator")?,
+            number_of_forms: number_of_forms.parse().unwrap_or(0),
             forms: None,
         })
     }
@@ -120,44 +104,25 @@ pub struct User {
 
 #[cfg(feature = "python")]
 impl User {
-    pub(crate) fn from_attributes(
-        attrs: HashMap<&str, &str>,
-    ) -> Result<Self, crate::errors::Error> {
-        let unique_id = attrs
-            .get("uniqueId")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing uniqueId".to_string(),
-                ))
-            })?;
+    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+        let mut unique_id: Option<&str> = None;
+        let mut last_language = "";
+        let mut creator: Option<&str> = None;
+        let mut number_of_forms = "";
 
-        let last_language = attrs
-            .get("lastLanguage")
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        let creator = attrs
-            .get("creator")
-            .copied()
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(
-                    "Missing creator".to_string(),
-                ))
-            })?;
-
-        let number_of_forms = attrs
-            .get("numberOfForms")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        visit_attributes(e, |key, attr| match key {
+            b"uniqueId" => unique_id = Some(attr),
+            b"lastLanguage" => last_language = attr,
+            b"creator" => creator = Some(attr),
+            b"numberOfForms" => number_of_forms = attr,
+            _ => {}
+        })?;
 
         Ok(User {
-            unique_id,
-            last_language,
-            creator,
-            number_of_forms,
+            unique_id: required_attribute(unique_id, "uniqueId")?,
+            last_language: optional_string(last_language),
+            creator: required_attribute(creator, "creator")?,
+            number_of_forms: number_of_forms.parse().unwrap_or(0),
             forms: None,
         })
     }


### PR DESCRIPTION
Use byte strings rather than hash maps to find the keys. This removed the need for double hashing the values (one on insert and one on lookup)