### PR TITLE
Wrap frequently copied String values in Arc<str>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ codegen-units = 1
 [workspace.dependencies]
 chrono = { version = "0.4.45", features = ["serde"] }
 pyo3 = "0.29.0"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive", "rc"] }
 thiserror = "2.0.18"

--- a/crates/prelude-xml-parser/src/lib.rs
+++ b/crates/prelude-xml-parser/src/lib.rs
@@ -6,7 +6,7 @@ use std::{fs::read_to_string, path::Path};
 use rayon::prelude::*;
 
 use crate::errors::Error;
-use crate::native::deserializers::{decode_error, push_general_ref, take_trimmed};
+use crate::native::deserializers::{decode_error, push_general_ref, take_trimmed, Interner};
 use crate::native::{
     common::{Category, Comment, Entry, Field, LockState, Reason, State, Value},
     site_native::{Site, SiteNative},
@@ -106,39 +106,39 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 /// let expected = SiteNative {
 ///     sites: vec![
 ///         Site {
-///             name: "Some Site".to_string(),
-///             unique_id: "1681574834910".to_string(),
+///             name: "Some Site".into(),
+///             unique_id: "1681574834910".into(),
 ///             number_of_patients: 4,
 ///             count_of_randomized_patients: 0,
 ///             when_created: Some(DateTime::parse_from_rfc3339("2023-04-15T16:08:19Z")
 ///                 .unwrap()
 ///                 .with_timezone(&Utc)),
-///             creator: "Paul Sanders".to_string(),
+///             creator: "Paul Sanders".into(),
 ///             number_of_forms: 1,
 ///             forms: Some(vec![Form {
-///                 name: "demographic.form.name.site.demographics".to_string(),
+///                 name: "demographic.form.name.site.demographics".into(),
 ///                 last_modified: Some(
 ///                     DateTime::parse_from_rfc3339("2023-04-15T16:08:19Z")
 ///                         .unwrap()
 ///                         .with_timezone(&Utc),
 ///                 ),
-///                 who_last_modified_name: Some("Paul Sanders".to_string()),
-///                 who_last_modified_role: Some("Project Manager".to_string()),
+///                 who_last_modified_name: Some("Paul Sanders".into()),
+///                 who_last_modified_role: Some("Project Manager".into()),
 ///                 when_created: 1681574834930,
 ///                 has_errors: false,
 ///                 has_warnings: false,
 ///                 locked: false,
 ///                 user: None,
 ///                 date_time_changed: None,
-///                 form_title: "Site Demographics".to_string(),
+///                 form_title: "Site Demographics".into(),
 ///                 form_index: 1,
-///                 form_group: Some("Demographic".to_string()),
-///                 form_state: "In-Work".to_string(),
+///                 form_group: Some("Demographic".into()),
+///                 form_state: "In-Work".into(),
 ///                 lock_state: None,
 ///                 states: Some(vec![State {
-///                     value: "form.state.in.work".to_string(),
-///                     signer: "Paul Sanders - Project Manager".to_string(),
-///                     signer_unique_id: "1681162687395".to_string(),
+///                     value: "form.state.in.work".into(),
+///                     signer: "Paul Sanders - Project Manager".into(),
+///                     signer_unique_id: "1681162687395".into(),
 ///                     date_signed: Some(
 ///                         DateTime::parse_from_rfc3339("2023-04-15T16:08:19Z")
 ///                             .unwrap()
@@ -147,15 +147,15 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                 }]),
 ///                 categories: Some(vec![
 ///                     Category {
-///                         name: "Demographics".to_string(),
-///                         category_type: "normal".to_string(),
+///                         name: "Demographics".into(),
+///                         category_type: "normal".into(),
 ///                         highest_index: 0,
 ///                         fields: Some(vec![
 ///                             Field {
-///                                 name: "address".to_string(),
-///                                 field_type: "text".to_string(),
-///                                 data_type: Some("string".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "address".into(),
+///                                 field_type: "text".into(),
+///                                 data_type: Some("string".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -166,10 +166,10 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 comments: None,
 ///                             },
 ///                             Field {
-///                                 name: "company".to_string(),
-///                                 field_type: "text".to_string(),
-///                                 data_type: Some("string".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "company".into(),
+///                                 field_type: "text".into(),
+///                                 data_type: Some("string".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -177,30 +177,30 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 .with_timezone(&Utc)),
 ///                                 keep_history: true,
 ///                                 entries: Some(vec![Entry {
-///                                     entry_id: "1".to_string(),
+///                                     entry_id: "1".into(),
 ///                                     reviewed_by: None,
 ///                                     reviewed_by_unique_id: None,
 ///                                     reviewed_by_when: None,
 ///                                     value: Some(Value {
-///                                         by: "Paul Sanders".to_string(),
-///                                         by_unique_id: Some("1681162687395".to_string()),
-///                                         role: "Project Manager".to_string(),
+///                                         by: "Paul Sanders".into(),
+///                                         by_unique_id: Some("1681162687395".into()),
+///                                         role: "Project Manager".into(),
 ///                                         when: Some(DateTime::parse_from_rfc3339(
 ///                                             "2023-04-15T16:08:19Z",
 ///                                         )
 ///                                         .unwrap()
 ///                                         .with_timezone(&Utc)),
-///                                         value: "Some Company".to_string(),
+///                                         value: "Some Company".into(),
 ///                                     }),
 ///                                     reason: None,
 ///                                 }]),
 ///                                 comments: None,
 ///                             },
 ///                             Field {
-///                                 name: "site_code_name".to_string(),
-///                                 field_type: "hidden".to_string(),
-///                                 data_type: Some("string".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "site_code_name".into(),
+///                                 field_type: "hidden".into(),
+///                                 data_type: Some("string".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -209,59 +209,59 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 keep_history: true,
 ///                                 entries: Some(vec![
 ///                                     Entry {
-///                                         entry_id: "1".to_string(),
+///                                         entry_id: "1".into(),
 ///                                         reviewed_by: None,
 ///                                         reviewed_by_unique_id: None,
 ///                                         reviewed_by_when: None,
 ///                                         value: Some(Value {
-///                                             by: "set from calculation".to_string(),
+///                                             by: "set from calculation".into(),
 ///                                             by_unique_id: None,
-///                                             role: "System".to_string(),
+///                                             role: "System".into(),
 ///                                             when: Some(DateTime::parse_from_rfc3339(
 ///                                                 "2023-04-15T16:08:19Z",
 ///                                             )
 ///                                             .unwrap()
 ///                                             .with_timezone(&Utc)),
-///                                             value: "ABC-Some Site".to_string(),
+///                                             value: "ABC-Some Site".into(),
 ///                                         }),
 ///                                         reason: Some(Reason {
-///                                             by: "set from calculation".to_string(),
+///                                             by: "set from calculation".into(),
 ///                                             by_unique_id: None,
-///                                             role: "System".to_string(),
+///                                             role: "System".into(),
 ///                                             when: Some(DateTime::parse_from_rfc3339(
 ///                                                 "2023-04-15T16:08:19Z",
 ///                                             )
 ///                                             .unwrap()
 ///                                             .with_timezone(&Utc)),
-///                                             value: "calculated value".to_string(),
+///                                             value: "calculated value".into(),
 ///                                         }),
 ///                                     },
 ///                                     Entry {
-///                                         entry_id: "2".to_string(),
+///                                         entry_id: "2".into(),
 ///                                         reviewed_by: None,
 ///                                         reviewed_by_unique_id: None,
 ///                                         reviewed_by_when: None,
 ///                                         value: Some(Value {
-///                                             by: "set from calculation".to_string(),
+///                                             by: "set from calculation".into(),
 ///                                             by_unique_id: None,
-///                                             role: "System".to_string(),
+///                                             role: "System".into(),
 ///                                             when: Some(DateTime::parse_from_rfc3339(
 ///                                                 "2023-04-15T16:07:24Z",
 ///                                             )
 ///                                             .unwrap()
 ///                                             .with_timezone(&Utc)),
-///                                             value: "Some Site".to_string(),
+///                                             value: "Some Site".into(),
 ///                                         }),
 ///                                         reason: Some(Reason {
-///                                             by: "set from calculation".to_string(),
+///                                             by: "set from calculation".into(),
 ///                                             by_unique_id: None,
-///                                             role: "System".to_string(),
+///                                             role: "System".into(),
 ///                                             when: Some(DateTime::parse_from_rfc3339(
 ///                                                 "2023-04-15T16:07:24Z",
 ///                                             )
 ///                                             .unwrap()
 ///                                             .with_timezone(&Utc)),
-///                                             value: "calculated value".to_string(),
+///                                             value: "calculated value".into(),
 ///                                         }),
 ///                                     },
 ///                                 ]),
@@ -270,15 +270,15 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                         ]),
 ///                     },
 ///                     Category {
-///                         name: "Enrollment".to_string(),
-///                         category_type: "normal".to_string(),
+///                         name: "Enrollment".into(),
+///                         category_type: "normal".into(),
 ///                         highest_index: 0,
 ///                         fields: Some(vec![
 ///                             Field {
-///                                 name: "enrollment_closed_date".to_string(),
-///                                 field_type: "popUpCalendar".to_string(),
-///                                 data_type: Some("date".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "enrollment_closed_date".into(),
+///                                 field_type: "popUpCalendar".into(),
+///                                 data_type: Some("date".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -289,10 +289,10 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 comments: None,
 ///                             },
 ///                             Field {
-///                                 name: "enrollment_open".to_string(),
-///                                 field_type: "radio".to_string(),
-///                                 data_type: Some("string".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "enrollment_open".into(),
+///                                 field_type: "radio".into(),
+///                                 data_type: Some("string".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -300,30 +300,30 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 .with_timezone(&Utc)),
 ///                                 keep_history: true,
 ///                                 entries: Some(vec![Entry {
-///                                     entry_id: "1".to_string(),
+///                                     entry_id: "1".into(),
 ///                                     reviewed_by: None,
 ///                                     reviewed_by_unique_id: None,
 ///                                     reviewed_by_when: None,
 ///                                     value: Some(Value {
-///                                         by: "Paul Sanders".to_string(),
-///                                         by_unique_id: Some("1681162687395".to_string()),
-///                                         role: "Project Manager".to_string(),
+///                                         by: "Paul Sanders".into(),
+///                                         by_unique_id: Some("1681162687395".into()),
+///                                         role: "Project Manager".into(),
 ///                                         when: Some(DateTime::parse_from_rfc3339(
 ///                                             "2023-04-15T16:08:19Z",
 ///                                         )
 ///                                         .unwrap()
 ///                                         .with_timezone(&Utc)),
-///                                         value: "Yes".to_string(),
+///                                         value: "Yes".into(),
 ///                                     }),
 ///                                     reason: None,
 ///                                 }]),
 ///                                 comments: None,
 ///                             },
 ///                             Field {
-///                                 name: "enrollment_open_date".to_string(),
-///                                 field_type: "popUpCalendar".to_string(),
-///                                 data_type: Some("date".to_string()),
-///                                 error_code: "valid".to_string(),
+///                                 name: "enrollment_open_date".into(),
+///                                 field_type: "popUpCalendar".into(),
+///                                 data_type: Some("date".into()),
+///                                 error_code: "valid".into(),
 ///                                 when_created: Some(DateTime::parse_from_rfc3339(
 ///                                     "2023-04-15T16:07:14Z",
 ///                                 )
@@ -339,39 +339,39 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///             }]),
 ///         },
 ///         Site {
-///             name: "Artemis".to_string(),
-///             unique_id: "1691420994591".to_string(),
+///             name: "Artemis".into(),
+///             unique_id: "1691420994591".into(),
 ///             number_of_patients: 0,
 ///             count_of_randomized_patients: 0,
 ///             when_created: Some(DateTime::parse_from_rfc3339("2023-08-07T15:14:23Z")
 ///                 .unwrap()
 ///                 .with_timezone(&Utc)),
-///             creator: "Paul Sanders".to_string(),
+///             creator: "Paul Sanders".into(),
 ///             number_of_forms: 1,
 ///             forms: Some(vec![Form {
-///                 name: "demographic.form.name.site.demographics".to_string(),
+///                 name: "demographic.form.name.site.demographics".into(),
 ///                 last_modified: Some(
 ///                     DateTime::parse_from_rfc3339("2023-08-07T15:14:23Z")
 ///                         .unwrap()
 ///                         .with_timezone(&Utc),
 ///                 ),
-///                 who_last_modified_name: Some("Paul Sanders".to_string()),
-///                 who_last_modified_role: Some("Project Manager".to_string()),
+///                 who_last_modified_name: Some("Paul Sanders".into()),
+///                 who_last_modified_role: Some("Project Manager".into()),
 ///                 when_created: 1691420994611,
 ///                 has_errors: false,
 ///                 has_warnings: false,
 ///                 locked: false,
 ///                 user: None,
 ///                 date_time_changed: None,
-///                 form_title: "Site Demographics".to_string(),
+///                 form_title: "Site Demographics".into(),
 ///                 form_index: 1,
-///                 form_group: Some("Demographic".to_string()),
-///                 form_state: "In-Work".to_string(),
+///                 form_group: Some("Demographic".into()),
+///                 form_state: "In-Work".into(),
 ///                 lock_state: None,
 ///                 states: Some(vec![State {
-///                     value: "form.state.in.work".to_string(),
-///                     signer: "Paul Sanders - Project Manager".to_string(),
-///                     signer_unique_id: "1681162687395".to_string(),
+///                     value: "form.state.in.work".into(),
+///                     signer: "Paul Sanders - Project Manager".into(),
+///                     signer_unique_id: "1681162687395".into(),
 ///                     date_signed: Some(
 ///                         DateTime::parse_from_rfc3339("2023-08-07T15:14:23Z")
 ///                             .unwrap()
@@ -379,44 +379,44 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                     ),
 ///                 }]),
 ///                 categories: Some(vec![Category {
-///                     name: "Demographics".to_string(),
-///                     category_type: "normal".to_string(),
+///                     name: "Demographics".into(),
+///                     category_type: "normal".into(),
 ///                     highest_index: 0,
 ///                     fields: Some(vec![Field {
-///                         name: "address".to_string(),
-///                         field_type: "text".to_string(),
-///                         data_type: Some("string".to_string()),
-///                         error_code: "valid".to_string(),
+///                         name: "address".into(),
+///                         field_type: "text".into(),
+///                         data_type: Some("string".into()),
+///                         error_code: "valid".into(),
 ///                         when_created: Some(DateTime::parse_from_rfc3339("2023-08-07T15:09:54Z")
 ///                             .unwrap()
 ///                             .with_timezone(&Utc)),
 ///                         keep_history: true,
 ///                         entries: Some(vec![Entry {
-///                             entry_id: "1".to_string(),
+///                             entry_id: "1".into(),
 ///                             reviewed_by: None,
 ///                             reviewed_by_unique_id: None,
 ///                             reviewed_by_when: None,
 ///                             value: Some(Value {
-///                                 by: "Paul Sanders".to_string(),
-///                                 by_unique_id: Some("1681162687395".to_string()),
-///                                 role: "Project Manager".to_string(),
+///                                 by: "Paul Sanders".into(),
+///                                 by_unique_id: Some("1681162687395".into()),
+///                                 role: "Project Manager".into(),
 ///                                 when: Some(DateTime::parse_from_rfc3339("2023-08-07T15:14:21Z")
 ///                                     .unwrap()
 ///                                     .with_timezone(&Utc)),
-///                                 value: "1111 Moon Drive".to_string(),
+///                                 value: "1111 Moon Drive".into(),
 ///                             }),
 ///                             reason: None,
 ///                         }]),
 ///                         comments: Some(vec![Comment {
-///                             comment_id: "1".to_string(),
+///                             comment_id: "1".into(),
 ///                             value: Some(Value {
-///                                 by: "Paul Sanders".to_string(),
-///                                 by_unique_id: Some("1681162687395".to_string()),
-///                                 role: "Project Manager".to_string(),
+///                                 by: "Paul Sanders".into(),
+///                                 by_unique_id: Some("1681162687395".into()),
+///                                 role: "Project Manager".into(),
 ///                                 when: Some(DateTime::parse_from_rfc3339("2023-08-07T15:14:21Z")
 ///                                     .unwrap()
 ///                                     .with_timezone(&Utc)),
-///                                 value: "Some comment".to_string(),
+///                                 value: "Some comment".into(),
 ///                             }),
 ///                         }]),
 ///                     }]),
@@ -503,38 +503,38 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 /// let expected = SubjectNative {
 ///     patients: vec![
 ///         Patient {
-///             patient_id: "ABC-001".to_string(),
-///             unique_id: "1681574905819".to_string(),
+///             patient_id: "ABC-001".into(),
+///             unique_id: "1681574905819".into(),
 ///             when_created: Some(DateTime::parse_from_rfc3339("2023-04-15T16:09:02Z")
 ///                 .unwrap()
 ///                 .with_timezone(&Utc)),
-///             creator: "Paul Sanders".to_string(),
-///             site_name: "Some Site".to_string(),
-///             site_unique_id: "1681574834910".to_string(),
-///             last_language: Some("English".to_string()),
+///             creator: "Paul Sanders".into(),
+///             site_name: "Some Site".into(),
+///             site_unique_id: "1681574834910".into(),
+///             last_language: Some("English".into()),
 ///             number_of_forms: 6,
 ///             forms: Some(vec![Form {
-///                 name: "day.0.form.name.demographics".to_string(),
+///                 name: "day.0.form.name.demographics".into(),
 ///                 last_modified: Some(DateTime::parse_from_rfc3339("2023-04-15T16:09:15Z")
 ///                     .unwrap()
 ///                     .with_timezone(&Utc)),
-///                 who_last_modified_name: Some("Paul Sanders".to_string()),
-///                 who_last_modified_role: Some("Project Manager".to_string()),
+///                 who_last_modified_name: Some("Paul Sanders".into()),
+///                 who_last_modified_role: Some("Project Manager".into()),
 ///                 when_created: 1681574905839,
 ///                 has_errors: false,
 ///                 has_warnings: false,
 ///                 locked: false,
 ///                 user: None,
 ///                 date_time_changed: None,
-///                 form_title: "Demographics".to_string(),
+///                 form_title: "Demographics".into(),
 ///                 form_index: 1,
-///                 form_group: Some("Day 0".to_string()),
-///                 form_state: "In-Work".to_string(),
+///                 form_group: Some("Day 0".into()),
+///                 form_state: "In-Work".into(),
 ///                 lock_state: None,
 ///                 states: Some(vec![State {
-///                     value: "form.state.in.work".to_string(),
-///                     signer: "Paul Sanders - Project Manager".to_string(),
-///                     signer_unique_id: "1681162687395".to_string(),
+///                     value: "form.state.in.work".into(),
+///                     signer: "Paul Sanders - Project Manager".into(),
+///                     signer_unique_id: "1681162687395".into(),
 ///                     date_signed: Some(
 ///                         DateTime::parse_from_rfc3339("2023-04-15T16:09:02Z")
 ///                             .unwrap()
@@ -542,31 +542,31 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                     ),
 ///                 }]),
 ///                 categories: Some(vec![Category {
-///                     name: "Demographics".to_string(),
-///                     category_type: "normal".to_string(),
+///                     name: "Demographics".into(),
+///                     category_type: "normal".into(),
 ///                     highest_index: 0,
 ///                     fields: Some(vec![Field {
-///                         name: "breed".to_string(),
-///                         field_type: "combo-box".to_string(),
-///                         data_type: Some("string".to_string()),
-///                         error_code: "valid".to_string(),
+///                         name: "breed".into(),
+///                         field_type: "combo-box".into(),
+///                         data_type: Some("string".into()),
+///                         error_code: "valid".into(),
 ///                         when_created: Some(DateTime::parse_from_rfc3339("2023-04-15T16:08:26Z")
 ///                             .unwrap()
 ///                             .with_timezone(&Utc)),
 ///                         keep_history: true,
 ///                         entries: Some(vec![Entry {
-///                             entry_id: "1".to_string(),
+///                             entry_id: "1".into(),
 ///                             reviewed_by: None,
 ///                             reviewed_by_unique_id: None,
 ///                             reviewed_by_when: None,
 ///                             value: Some(Value {
-///                                 by: "Paul Sanders".to_string(),
-///                                 by_unique_id: Some("1681162687395".to_string()),
-///                                 role: "Project Manager".to_string(),
+///                                 by: "Paul Sanders".into(),
+///                                 by_unique_id: Some("1681162687395".into()),
+///                                 role: "Project Manager".into(),
 ///                                 when: Some(DateTime::parse_from_rfc3339("2023-04-15T16:09:02Z")
 ///                                     .unwrap()
 ///                                     .with_timezone(&Utc)),
-///                                 value: "Labrador".to_string(),
+///                                 value: "Labrador".into(),
 ///                             }),
 ///                             reason: None,
 ///                         }]),
@@ -576,38 +576,38 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///             }]),
 ///         },
 ///         Patient {
-///             patient_id: "DEF-002".to_string(),
-///             unique_id: "1681574905820".to_string(),
+///             patient_id: "DEF-002".into(),
+///             unique_id: "1681574905820".into(),
 ///             when_created: Some(DateTime::parse_from_rfc3339("2023-04-16T16:10:02Z")
 ///                 .unwrap()
 ///                 .with_timezone(&Utc)),
-///             creator: "Wade Watts".to_string(),
-///             site_name: "Another Site".to_string(),
-///             site_unique_id: "1681574834911".to_string(),
+///             creator: "Wade Watts".into(),
+///             site_name: "Another Site".into(),
+///             site_unique_id: "1681574834911".into(),
 ///             last_language: None,
 ///             number_of_forms: 8,
 ///             forms: Some(vec![Form {
-///                 name: "day.0.form.name.demographics".to_string(),
+///                 name: "day.0.form.name.demographics".into(),
 ///                 last_modified: Some(DateTime::parse_from_rfc3339("2023-04-16T16:10:15Z")
 ///                     .unwrap()
 ///                     .with_timezone(&Utc)),
-///                 who_last_modified_name: Some("Barney Rubble".to_string()),
-///                 who_last_modified_role: Some("Technician".to_string()),
+///                 who_last_modified_name: Some("Barney Rubble".into()),
+///                 who_last_modified_role: Some("Technician".into()),
 ///                 when_created: 1681574905838,
 ///                 has_errors: false,
 ///                 has_warnings: false,
 ///                 locked: false,
 ///                 user: None,
 ///                 date_time_changed: None,
-///                 form_title: "Demographics".to_string(),
+///                 form_title: "Demographics".into(),
 ///                 form_index: 1,
-///                 form_group: Some("Day 0".to_string()),
-///                 form_state: "In-Work".to_string(),
+///                 form_group: Some("Day 0".into()),
+///                 form_state: "In-Work".into(),
 ///                 lock_state: None,
 ///                 states: Some(vec![State {
-///                     value: "form.state.in.work".to_string(),
-///                     signer: "Paul Sanders - Project Manager".to_string(),
-///                     signer_unique_id: "1681162687395".to_string(),
+///                     value: "form.state.in.work".into(),
+///                     signer: "Paul Sanders - Project Manager".into(),
+///                     signer_unique_id: "1681162687395".into(),
 ///                     date_signed: Some(
 ///                         DateTime::parse_from_rfc3339("2023-04-16T16:10:02Z")
 ///                             .unwrap()
@@ -615,31 +615,31 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                     ),
 ///                 }]),
 ///                 categories: Some(vec![Category {
-///                     name: "Demographics".to_string(),
-///                     category_type: "normal".to_string(),
+///                     name: "Demographics".into(),
+///                     category_type: "normal".into(),
 ///                     highest_index: 0,
 ///                     fields: Some(vec![Field {
-///                         name: "breed".to_string(),
-///                         field_type: "combo-box".to_string(),
-///                         data_type: Some("string".to_string()),
-///                         error_code: "valid".to_string(),
+///                         name: "breed".into(),
+///                         field_type: "combo-box".into(),
+///                         data_type: Some("string".into()),
+///                         error_code: "valid".into(),
 ///                         when_created: Some(DateTime::parse_from_rfc3339("2023-04-15T16:08:26Z")
 ///                             .unwrap()
 ///                             .with_timezone(&Utc)),
 ///                         keep_history: true,
 ///                         entries: Some(vec![Entry {
-///                             entry_id: "1".to_string(),
+///                             entry_id: "1".into(),
 ///                             reviewed_by: None,
 ///                             reviewed_by_unique_id: None,
 ///                             reviewed_by_when: None,
 ///                             value: Some(Value {
-///                                 by: "Paul Sanders".to_string(),
-///                                 by_unique_id: Some("1681162687395".to_string()),
-///                                 role: "Project Manager".to_string(),
+///                                 by: "Paul Sanders".into(),
+///                                 by_unique_id: Some("1681162687395".into()),
+///                                 role: "Project Manager".into(),
 ///                                 when: Some(DateTime::parse_from_rfc3339("2023-04-15T16:09:02Z")
 ///                                     .unwrap()
 ///                                     .with_timezone(&Utc)),
-///                                 value: "Labrador".to_string(),
+///                                 value: "Labrador".into(),
 ///                             }),
 ///                             reason: None,
 ///                         }]),
@@ -687,6 +687,7 @@ fn extract_patient_chunks(xml: &str) -> Vec<&str> {
 
 #[allow(clippy::drain_collect)]
 fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
+    let mut interner = Interner::default();
     let mut xml_reader = Reader::from_str(patient_xml);
     xml_reader.config_mut().trim_text(false);
 
@@ -737,18 +738,18 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                             current_categories.clear();
                         }
                         "category" if in_form => {
-                            current_category = Some(Category::from_attributes(e)?);
+                            current_category = Some(Category::from_attributes(e, &mut interner)?);
                             in_category = true;
                             current_fields.clear();
                         }
                         "field" if in_category => {
-                            current_field = Some(Field::from_attributes(e)?);
+                            current_field = Some(Field::from_attributes(e, &mut interner)?);
                             in_field = true;
                             current_entries.clear();
                             current_comments.clear();
                         }
                         "entry" if in_field => {
-                            current_entry = Some(Entry::from_attributes(e)?);
+                            current_entry = Some(Entry::from_attributes(e, &mut interner)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
@@ -756,12 +757,12 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            current_value = Some(Value::from_attributes(e)?);
+                            current_value = Some(Value::from_attributes(e, &mut interner)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            current_reason = Some(Reason::from_attributes(e)?);
+                            current_reason = Some(Reason::from_attributes(e, &mut interner)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -865,7 +866,7 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let state = State::from_attributes(e)?;
+                            let state = State::from_attributes(e, &mut interner)?;
                             current_states.push(state);
                         }
                         "lockState" if in_form => {
@@ -875,19 +876,19 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                             }
                         }
                         "category" if in_form => {
-                            current_categories.push(Category::from_attributes(e)?);
+                            current_categories.push(Category::from_attributes(e, &mut interner)?);
                         }
                         "field" if in_category => {
-                            current_fields.push(Field::from_attributes(e)?);
+                            current_fields.push(Field::from_attributes(e, &mut interner)?);
                         }
                         "value" if in_entry => {
-                            let value = Value::from_attributes(e)?;
+                            let value = Value::from_attributes(e, &mut interner)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.value = Some(value);
                             }
                         }
                         "reason" if in_entry => {
-                            let reason = Reason::from_attributes(e)?;
+                            let reason = Reason::from_attributes(e, &mut interner)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.reason = Some(reason);
                             }
@@ -932,6 +933,7 @@ fn extract_site_chunks(xml: &str) -> Vec<&str> {
 
 #[allow(clippy::drain_collect)]
 fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
+    let mut interner = Interner::default();
     let mut xml_reader = Reader::from_str(site_xml);
     xml_reader.config_mut().trim_text(false);
 
@@ -982,18 +984,18 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                             current_categories.clear();
                         }
                         "category" if in_form => {
-                            current_category = Some(Category::from_attributes(e)?);
+                            current_category = Some(Category::from_attributes(e, &mut interner)?);
                             in_category = true;
                             current_fields.clear();
                         }
                         "field" if in_category => {
-                            current_field = Some(Field::from_attributes(e)?);
+                            current_field = Some(Field::from_attributes(e, &mut interner)?);
                             in_field = true;
                             current_entries.clear();
                             current_comments.clear();
                         }
                         "entry" if in_field => {
-                            current_entry = Some(Entry::from_attributes(e)?);
+                            current_entry = Some(Entry::from_attributes(e, &mut interner)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
@@ -1001,12 +1003,12 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            current_value = Some(Value::from_attributes(e)?);
+                            current_value = Some(Value::from_attributes(e, &mut interner)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            current_reason = Some(Reason::from_attributes(e)?);
+                            current_reason = Some(Reason::from_attributes(e, &mut interner)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -1110,7 +1112,7 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let state = State::from_attributes(e)?;
+                            let state = State::from_attributes(e, &mut interner)?;
                             current_states.push(state);
                         }
                         "lockState" if in_form => {
@@ -1120,20 +1122,20 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                             }
                         }
                         "category" if in_form => {
-                            current_categories.push(Category::from_attributes(e)?);
+                            current_categories.push(Category::from_attributes(e, &mut interner)?);
                         }
                         "field" if in_category => {
-                            let field = Field::from_attributes(e)?;
+                            let field = Field::from_attributes(e, &mut interner)?;
                             current_fields.push(field);
                         }
                         "value" if in_entry => {
-                            let value = Value::from_attributes(e)?;
+                            let value = Value::from_attributes(e, &mut interner)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.value = Some(value);
                             }
                         }
                         "reason" if in_entry => {
-                            let reason = Reason::from_attributes(e)?;
+                            let reason = Reason::from_attributes(e, &mut interner)?;
                             if let Some(ref mut entry) = current_entry {
                                 entry.reason = Some(reason);
                             }
@@ -1214,34 +1216,34 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///
 /// let expected = UserNative {
 ///     users: vec![User {
-///         unique_id: "1691421275437".to_string(),
+///         unique_id: "1691421275437".into(),
 ///         last_language: None,
-///         creator: "Paul Sanders(1681162687395)".to_string(),
+///         creator: "Paul Sanders(1681162687395)".into(),
 ///         number_of_forms: 1,
 ///         forms: Some(vec![Form {
-///             name: "form.name.demographics".to_string(),
+///             name: "form.name.demographics".into(),
 ///             last_modified: Some(
 ///                 DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                     .unwrap()
 ///                     .with_timezone(&Utc),
 ///             ),
-///             who_last_modified_name: Some("Paul Sanders".to_string()),
-///             who_last_modified_role: Some("Project Manager".to_string()),
+///             who_last_modified_name: Some("Paul Sanders".into()),
+///             who_last_modified_role: Some("Project Manager".into()),
 ///             when_created: 1691421341578,
 ///             has_errors: false,
 ///             has_warnings: false,
 ///             locked: false,
 ///             user: None,
 ///             date_time_changed: None,
-///             form_title: "User Demographics".to_string(),
+///             form_title: "User Demographics".into(),
 ///             form_index: 1,
 ///             form_group: None,
-///             form_state: "In-Work".to_string(),
+///             form_state: "In-Work".into(),
 ///             lock_state: None,
 ///             states: Some(vec![State {
-///                 value: "form.state.in.work".to_string(),
-///                 signer: "Paul Sanders - Project Manager".to_string(),
-///                 signer_unique_id: "1681162687395".to_string(),
+///                 value: "form.state.in.work".into(),
+///                 signer: "Paul Sanders - Project Manager".into(),
+///                 signer_unique_id: "1681162687395".into(),
 ///                 date_signed: Some(
 ///                     DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                         .unwrap()
@@ -1250,15 +1252,15 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///             }]),
 ///             categories: Some(vec![
 ///                         Category {
-///                             name: "demographics".to_string(),
-///                             category_type: "normal".to_string(),
+///                             name: "demographics".into(),
+///                             category_type: "normal".into(),
 ///                             highest_index: 0,
 ///                             fields: Some(vec![
 ///                                 Field {
-///                                     name: "address".to_string(),
-///                                     field_type: "text".to_string(),
-///                                     data_type: Some("string".to_string()),
-///                                     error_code: "undefined".to_string(),
+///                                     name: "address".into(),
+///                                     field_type: "text".into(),
+///                                     data_type: Some("string".into()),
+///                                     error_code: "undefined".into(),
 ///                                     when_created: Some(DateTime::parse_from_rfc3339("2024-01-12T20:14:09Z")
 ///                                         .unwrap()
 ///                                         .with_timezone(&Utc)),
@@ -1267,27 +1269,27 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///                                     comments: None,
 ///                                 },
 ///                                 Field {
-///                                     name: "email".to_string(),
-///                                     field_type: "text".to_string(),
-///                                     data_type: Some("string".to_string()),
-///                                     error_code: "undefined".to_string(),
+///                                     name: "email".into(),
+///                                     field_type: "text".into(),
+///                                     data_type: Some("string".into()),
+///                                     error_code: "undefined".into(),
 ///                                     when_created: Some(DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                                         .unwrap()
 ///                                         .with_timezone(&Utc)),
 ///                                     keep_history: true,
 ///                                     entries: Some(vec![Entry {
-///                                         entry_id: "1".to_string(),
+///                                         entry_id: "1".into(),
 ///                                         reviewed_by: None,
 ///                                         reviewed_by_unique_id: None,
 ///                                         reviewed_by_when: None,
 ///                                         value: Some(Value {
-///                                             by: "Paul Sanders".to_string(),
-///                                             by_unique_id: Some("1681162687395".to_string()),
-///                                             role: "Project Manager".to_string(),
+///                                             by: "Paul Sanders".into(),
+///                                             by_unique_id: Some("1681162687395".into()),
+///                                             role: "Project Manager".into(),
 ///                                             when: Some(DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                                                 .unwrap()
 ///                                                 .with_timezone(&Utc)),
-///                                             value: "jazz@artemis.com".to_string(),
+///                                             value: "jazz@artemis.com".into(),
 ///                                         }),
 ///                                         reason: None,
 ///                                     }]),
@@ -1296,42 +1298,42 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///                             ]),
 ///                         },
 ///                         Category {
-///                             name: "Administrative".to_string(),
-///                             category_type: "normal".to_string(),
+///                             name: "Administrative".into(),
+///                             category_type: "normal".into(),
 ///                             highest_index: 0,
 ///                             fields: Some(vec![
 ///                                 Field {
-///                                     name: "study_assignment".to_string(),
-///                                     field_type: "text".to_string(),
+///                                     name: "study_assignment".into(),
+///                                     field_type: "text".into(),
 ///                                     data_type: None,
-///                                     error_code: "undefined".to_string(),
+///                                     error_code: "undefined".into(),
 ///                                     when_created: Some(DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                                         .unwrap()
 ///                                         .with_timezone(&Utc)),
 ///                                     keep_history: true,
 ///                                     entries: Some(vec![
 ///                                         Entry {
-///                                             entry_id: "1".to_string(),
+///                                             entry_id: "1".into(),
 ///                                             reviewed_by: None,
 ///                                             reviewed_by_unique_id: None,
 ///                                             reviewed_by_when: None,
 ///                                             value: Some(Value {
-///                                                 by: "set from calculation".to_string(),
+///                                                 by: "set from calculation".into(),
 ///                                                 by_unique_id: None,
-///                                                 role: "System".to_string(),
+///                                                 role: "System".into(),
 ///                                                 when: Some(DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                                                     .unwrap()
 ///                                                     .with_timezone(&Utc)),
-///                                                 value: "On 07-Aug-2023 10:15 -0500, Paul Sanders assigned user from another study".to_string(),
+///                                                 value: "On 07-Aug-2023 10:15 -0500, Paul Sanders assigned user from another study".into(),
 ///                                             }),
 ///                                             reason: Some(Reason {
-///                                                 by: "set from calculation".to_string(),
+///                                                 by: "set from calculation".into(),
 ///                                                 by_unique_id: None,
-///                                                 role: "System".to_string(),
+///                                                 role: "System".into(),
 ///                                                 when: Some(DateTime::parse_from_rfc3339("2023-08-07T15:15:41Z")
 ///                                                     .unwrap()
 ///                                                     .with_timezone(&Utc)),
-///                                                 value: "calculated value".to_string(),
+///                                                 value: "calculated value".into(),
 ///                                             }),
 ///                                         },
 ///                                     ]),
@@ -1381,6 +1383,7 @@ fn extract_user_chunks(xml: &str) -> Vec<&str> {
 
 #[allow(clippy::drain_collect)]
 fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
+    let mut interner = Interner::default();
     let mut xml_reader = Reader::from_str(user_xml);
     xml_reader.config_mut().trim_text(false);
 
@@ -1428,15 +1431,15 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                             in_form = true;
                         }
                         "category" if in_form => {
-                            current_category = Some(Category::from_attributes(e)?);
+                            current_category = Some(Category::from_attributes(e, &mut interner)?);
                             in_category = true;
                         }
                         "field" if in_category => {
-                            current_field = Some(Field::from_attributes(e)?);
+                            current_field = Some(Field::from_attributes(e, &mut interner)?);
                             in_field = true;
                         }
                         "entry" if in_field => {
-                            current_entry = Some(Entry::from_attributes(e)?);
+                            current_entry = Some(Entry::from_attributes(e, &mut interner)?);
                             in_entry = true;
                         }
                         "comment" if in_field => {
@@ -1444,12 +1447,12 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                             in_comment = true;
                         }
                         "value" if in_entry || in_comment => {
-                            current_value = Some(Value::from_attributes(e)?);
+                            current_value = Some(Value::from_attributes(e, &mut interner)?);
                             in_value = true;
                             text_content.clear();
                         }
                         "reason" if in_entry => {
-                            current_reason = Some(Reason::from_attributes(e)?);
+                            current_reason = Some(Reason::from_attributes(e, &mut interner)?);
                             in_reason = true;
                             text_content.clear();
                         }
@@ -1553,14 +1556,14 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                 if let Ok(name) = std::str::from_utf8(name_bytes.as_ref()) {
                     match name {
                         "state" if in_form => {
-                            let state = State::from_attributes(e)?;
+                            let state = State::from_attributes(e, &mut interner)?;
                             current_states.push(state);
                         }
                         "category" if in_form => {
-                            current_categories.push(Category::from_attributes(e)?);
+                            current_categories.push(Category::from_attributes(e, &mut interner)?);
                         }
                         "field" if in_category => {
-                            let field = Field::from_attributes(e)?;
+                            let field = Field::from_attributes(e, &mut interner)?;
                             current_fields.push(field);
                         }
                         _ => {}
@@ -1703,33 +1706,33 @@ mod tests {
 
         let states1 = form1.states.as_ref().expect("Form 1 should have states");
         assert_eq!(states1.len(), 1);
-        assert_eq!(states1[0].value, "form.state.in.work");
+        assert_eq!(&*states1[0].value, "form.state.in.work");
 
         let categories1 = form1
             .categories
             .as_ref()
             .expect("Form 1 should have categories");
         assert_eq!(categories1.len(), 1);
-        assert_eq!(categories1[0].name, "Test Category");
+        assert_eq!(&*categories1[0].name, "Test Category");
 
         let fields1 = categories1[0]
             .fields
             .as_ref()
             .expect("Category should have fields");
         assert_eq!(fields1.len(), 1);
-        assert_eq!(fields1[0].name, "test_field");
+        assert_eq!(&*fields1[0].name, "test_field");
 
         let entries1 = fields1[0]
             .entries
             .as_ref()
             .expect("Field should have entries");
         assert_eq!(entries1.len(), 1);
-        assert_eq!(entries1[0].entry_id, "1");
+        assert_eq!(&*entries1[0].entry_id, "1");
 
         let value1 = entries1[0].value.as_ref().expect("Entry should have value");
         assert_eq!(value1.value, "Test Value");
-        assert_eq!(value1.by, "Test User");
-        assert_eq!(value1.role, "Tester");
+        assert_eq!(&*value1.by, "Test User");
+        assert_eq!(&*value1.role, "Tester");
 
         let form2 = &forms[1];
         assert_eq!(form2.name, "test.form.2");
@@ -1739,7 +1742,7 @@ mod tests {
 
         let states2 = form2.states.as_ref().expect("Form 2 should have states");
         assert_eq!(states2.len(), 1);
-        assert_eq!(states2[0].value, "form.state.complete");
+        assert_eq!(&*states2[0].value, "form.state.complete");
     }
 
     #[test]
@@ -1788,7 +1791,7 @@ mod tests {
         assert_eq!(fields.len(), 2, "Should have 2 fields");
 
         let field_with_comments = &fields[0];
-        assert_eq!(field_with_comments.name, "field_with_comments");
+        assert_eq!(&*field_with_comments.name, "field_with_comments");
 
         let comments = field_with_comments
             .comments
@@ -1803,8 +1806,8 @@ mod tests {
             .as_ref()
             .expect("Comment 1 should have value");
         assert_eq!(comment1_value.value, "First comment");
-        assert_eq!(comment1_value.by, "Test User");
-        assert_eq!(comment1_value.role, "Tester");
+        assert_eq!(&*comment1_value.by, "Test User");
+        assert_eq!(&*comment1_value.role, "Tester");
 
         let comment2 = &comments[1];
         assert_eq!(comment2.comment_id, "2");
@@ -1813,11 +1816,11 @@ mod tests {
             .as_ref()
             .expect("Comment 2 should have value");
         assert_eq!(comment2_value.value, "Second comment");
-        assert_eq!(comment2_value.by, "Another User");
-        assert_eq!(comment2_value.role, "Reviewer");
+        assert_eq!(&*comment2_value.by, "Another User");
+        assert_eq!(&*comment2_value.role, "Reviewer");
 
         let field_without_comments = &fields[1];
-        assert_eq!(field_without_comments.name, "field_without_comments");
+        assert_eq!(&*field_without_comments.name, "field_without_comments");
         assert!(
             field_without_comments.comments.is_none(),
             "Field without comments should have no comments"

--- a/crates/prelude-xml-parser/src/native/common.rs
+++ b/crates/prelude-xml-parser/src/native/common.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -10,9 +12,9 @@ use pyo3::{
 use quick_xml::events::BytesStart;
 
 use crate::native::deserializers::{
-    checked_datetime, default_datetime_none, default_string_none, deserialize_empty_string_as_none,
+    checked_datetime, deserialize_empty_string_as_none, deserialize_empty_string_as_none_arc,
     deserialize_empty_string_as_none_datetime, optional_datetime, optional_string,
-    visit_attributes,
+    visit_attributes, Interner,
 };
 
 #[cfg(feature = "python")]
@@ -24,20 +26,17 @@ pub struct Value {
     #[serde(rename = "by")]
     #[serde(alias = "@by")]
     #[serde(alias = "by")]
-    pub by: String,
+    pub by: Arc<str>,
 
     #[serde(rename = "byUniqueId")]
     #[serde(alias = "@byUniqueId")]
     #[serde(alias = "byUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub by_unique_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub by_unique_id: Option<Arc<str>>,
     #[serde(rename = "role")]
     #[serde(alias = "@role")]
     #[serde(alias = "role")]
-    pub role: String,
+    pub role: Arc<str>,
     #[serde(rename = "when")]
     #[serde(alias = "@when")]
     #[serde(alias = "when")]
@@ -58,20 +57,17 @@ pub struct Value {
     #[serde(rename = "by")]
     #[serde(alias = "@by")]
     #[serde(alias = "by")]
-    pub by: String,
+    pub by: Arc<str>,
 
     #[serde(rename = "byUniqueId")]
     #[serde(alias = "@byUniqueId")]
     #[serde(alias = "byUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub by_unique_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub by_unique_id: Option<Arc<str>>,
     #[serde(rename = "role")]
     #[serde(alias = "@role")]
     #[serde(alias = "role")]
-    pub role: String,
+    pub role: Arc<str>,
     #[serde(rename = "when")]
     #[serde(alias = "@when")]
     #[serde(alias = "when")]
@@ -90,17 +86,17 @@ pub struct Value {
 impl Value {
     #[getter]
     fn by(&self) -> PyResult<String> {
-        Ok(self.by.clone())
+        Ok(self.by.to_string())
     }
 
     #[getter]
     fn by_unique_id(&self) -> PyResult<Option<String>> {
-        Ok(self.by_unique_id.clone())
+        Ok(self.by_unique_id.as_deref().map(str::to_string))
     }
 
     #[getter]
     fn role(&self) -> PyResult<String> {
-        Ok(self.role.clone())
+        Ok(self.role.to_string())
     }
 
     #[getter]
@@ -115,9 +111,9 @@ impl Value {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("by", &self.by)?;
-        dict.set_item("by_unique_id", &self.by_unique_id)?;
-        dict.set_item("role", &self.role)?;
+        dict.set_item("by", &*self.by)?;
+        dict.set_item("by_unique_id", self.by_unique_id.as_deref())?;
+        dict.set_item("role", &*self.role)?;
         dict.set_item("when", to_py_datetime_option(py, &self.when)?)?;
         dict.set_item("value", &self.value)?;
 
@@ -131,21 +127,18 @@ pub struct Reason {
     #[serde(rename = "by")]
     #[serde(alias = "@by")]
     #[serde(alias = "by")]
-    pub by: String,
+    pub by: Arc<str>,
 
     #[serde(rename = "byUniqueId")]
     #[serde(alias = "@byUniqueId")]
     #[serde(alias = "byUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub by_unique_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub by_unique_id: Option<Arc<str>>,
 
     #[serde(rename = "role")]
     #[serde(alias = "@role")]
     #[serde(alias = "role")]
-    pub role: String,
+    pub role: Arc<str>,
     #[serde(rename = "when")]
     #[serde(alias = "@when")]
     #[serde(alias = "when")]
@@ -166,21 +159,18 @@ pub struct Reason {
     #[serde(rename = "by")]
     #[serde(alias = "@by")]
     #[serde(alias = "by")]
-    pub by: String,
+    pub by: Arc<str>,
 
     #[serde(rename = "byUniqueId")]
     #[serde(alias = "@byUniqueId")]
     #[serde(alias = "byUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub by_unique_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub by_unique_id: Option<Arc<str>>,
 
     #[serde(rename = "role")]
     #[serde(alias = "@role")]
     #[serde(alias = "role")]
-    pub role: String,
+    pub role: Arc<str>,
     #[serde(rename = "when")]
     #[serde(alias = "@when")]
     #[serde(alias = "when")]
@@ -199,17 +189,17 @@ pub struct Reason {
 impl Reason {
     #[getter]
     fn by(&self) -> PyResult<String> {
-        Ok(self.by.clone())
+        Ok(self.by.to_string())
     }
 
     #[getter]
     fn by_unique_id(&self) -> PyResult<Option<String>> {
-        Ok(self.by_unique_id.clone())
+        Ok(self.by_unique_id.as_deref().map(str::to_string))
     }
 
     #[getter]
     fn role(&self) -> PyResult<String> {
-        Ok(self.role.clone())
+        Ok(self.role.to_string())
     }
 
     #[getter]
@@ -224,9 +214,9 @@ impl Reason {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("by", &self.by)?;
-        dict.set_item("by_unique_id", &self.by_unique_id)?;
-        dict.set_item("role", &self.role)?;
+        dict.set_item("by", &*self.by)?;
+        dict.set_item("by_unique_id", self.by_unique_id.as_deref())?;
+        dict.set_item("role", &*self.role)?;
         dict.set_item("when", to_py_datetime_option(py, &self.when)?)?;
         dict.set_item("value", &self.value)?;
 
@@ -240,31 +230,25 @@ pub struct Entry {
     #[serde(rename = "entryId")]
     #[serde(alias = "@id")]
     #[serde(alias = "entryId")]
-    pub entry_id: String,
+    pub entry_id: Arc<str>,
 
     #[serde(rename = "reviewedBy")]
     #[serde(alias = "@reviewedBy")]
     #[serde(alias = "reviewedBy")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub reviewed_by: Option<String>,
 
     #[serde(rename = "reviewedByUniqueId")]
     #[serde(alias = "@reviewedByUniqueId")]
     #[serde(alias = "reviewedByUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub reviewed_by_unique_id: Option<String>,
 
     #[serde(rename = "reviewedByWhen")]
     #[serde(alias = "@reviewedByWhen")]
     #[serde(alias = "reviewedByWhen")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub reviewed_by_when: Option<DateTime<Utc>>,
@@ -280,31 +264,25 @@ pub struct Entry {
     #[serde(rename = "entryId")]
     #[serde(alias = "@id")]
     #[serde(alias = "entryId")]
-    pub entry_id: String,
+    pub entry_id: Arc<str>,
 
     #[serde(rename = "reviewedBy")]
     #[serde(alias = "@reviewedBy")]
     #[serde(alias = "reviewedBy")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub reviewed_by: Option<String>,
 
     #[serde(rename = "reviewedByUniqueId")]
     #[serde(alias = "@reviewedByUniqueId")]
     #[serde(alias = "reviewedByUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub reviewed_by_unique_id: Option<String>,
 
     #[serde(rename = "reviewedByWhen")]
     #[serde(alias = "@reviewedByWhen")]
     #[serde(alias = "reviewedByWhen")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub reviewed_by_when: Option<DateTime<Utc>>,
@@ -318,7 +296,7 @@ pub struct Entry {
 impl Entry {
     #[getter]
     fn entry_id(&self) -> PyResult<String> {
-        Ok(self.entry_id.clone())
+        Ok(self.entry_id.to_string())
     }
 
     #[getter]
@@ -348,7 +326,7 @@ impl Entry {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("entry_id", &self.entry_id)?;
+        dict.set_item("entry_id", &*self.entry_id)?;
         dict.set_item("reviewed_by", &self.reviewed_by)?;
         dict.set_item("reviewed_by_unique_id", &self.reviewed_by_unique_id)?;
         dict.set_item(
@@ -423,25 +401,22 @@ pub struct Field {
     #[serde(rename = "name")]
     #[serde(alias = "@name")]
     #[serde(alias = "name")]
-    pub name: String,
+    pub name: Arc<str>,
 
     #[serde(rename = "fieldType")]
     #[serde(alias = "@type")]
     #[serde(alias = "fieldType")]
-    pub field_type: String,
+    pub field_type: Arc<str>,
 
     #[serde(rename = "dataType")]
     #[serde(alias = "@dataType")]
     #[serde(alias = "dataType")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub data_type: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub data_type: Option<Arc<str>>,
     #[serde(rename = "errorCode")]
     #[serde(alias = "@errorCode")]
     #[serde(alias = "errorCode")]
-    pub error_code: String,
+    pub error_code: Arc<str>,
     #[serde(rename = "whenCreated")]
     #[serde(alias = "@whenCreated")]
     #[serde(alias = "whenCreated")]
@@ -465,26 +440,23 @@ pub struct Field {
     #[serde(rename = "name")]
     #[serde(alias = "@name")]
     #[serde(alias = "name")]
-    pub name: String,
+    pub name: Arc<str>,
 
     #[serde(rename = "fieldType")]
     #[serde(alias = "@type")]
     #[serde(alias = "fieldType")]
-    pub field_type: String,
+    pub field_type: Arc<str>,
 
     #[serde(rename = "dataType")]
     #[serde(alias = "@dataType")]
     #[serde(alias = "dataType")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
-    pub data_type: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none_arc")]
+    pub data_type: Option<Arc<str>>,
 
     #[serde(rename = "errorCode")]
     #[serde(alias = "@errorCode")]
     #[serde(alias = "errorCode")]
-    pub error_code: String,
+    pub error_code: Arc<str>,
     #[serde(rename = "whenCreated")]
     #[serde(alias = "@whenCreated")]
     #[serde(alias = "whenCreated")]
@@ -506,22 +478,22 @@ pub struct Field {
 impl Field {
     #[getter]
     fn name(&self) -> PyResult<String> {
-        Ok(self.name.clone())
+        Ok(self.name.to_string())
     }
 
     #[getter]
     fn field_type(&self) -> PyResult<String> {
-        Ok(self.field_type.clone())
+        Ok(self.field_type.to_string())
     }
 
     #[getter]
     fn data_type(&self) -> PyResult<Option<String>> {
-        Ok(self.data_type.clone())
+        Ok(self.data_type.as_deref().map(str::to_string))
     }
 
     #[getter]
     fn error_code(&self) -> PyResult<String> {
-        Ok(self.error_code.clone())
+        Ok(self.error_code.to_string())
     }
 
     #[getter]
@@ -549,10 +521,10 @@ impl Field {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("name", &self.name)?;
-        dict.set_item("field_type", &self.field_type)?;
-        dict.set_item("data_type", &self.data_type)?;
-        dict.set_item("error_code", &self.error_code)?;
+        dict.set_item("name", &*self.name)?;
+        dict.set_item("field_type", &*self.field_type)?;
+        dict.set_item("data_type", self.data_type.as_deref())?;
+        dict.set_item("error_code", &*self.error_code)?;
         dict.set_item(
             "when_created",
             self.when_created
@@ -594,12 +566,12 @@ pub struct Category {
     #[serde(rename = "name")]
     #[serde(alias = "@name")]
     #[serde(alias = "name")]
-    pub name: String,
+    pub name: Arc<str>,
 
     #[serde(rename = "categoryType")]
     #[serde(alias = "@type")]
     #[serde(alias = "categoryType")]
-    pub category_type: String,
+    pub category_type: Arc<str>,
 
     #[serde(rename = "highestIndex")]
     #[serde(alias = "@highestIndex")]
@@ -612,17 +584,17 @@ pub struct Category {
 
 #[cfg(feature = "python")]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[pyclass(get_all, skip_from_py_object)]
+#[pyclass(skip_from_py_object)]
 pub struct Category {
     #[serde(rename = "name")]
     #[serde(alias = "@name")]
     #[serde(alias = "name")]
-    pub name: String,
+    pub name: Arc<str>,
 
     #[serde(rename = "categoryType")]
     #[serde(alias = "@type")]
     #[serde(alias = "categoryType")]
-    pub category_type: String,
+    pub category_type: Arc<str>,
 
     #[serde(rename = "highestIndex")]
     #[serde(alias = "@highestIndex")]
@@ -638,12 +610,12 @@ pub struct Category {
 impl Category {
     #[getter]
     fn name(&self) -> PyResult<String> {
-        Ok(self.name.clone())
+        Ok(self.name.to_string())
     }
 
     #[getter]
     fn category_type(&self) -> PyResult<String> {
-        Ok(self.category_type.clone())
+        Ok(self.category_type.to_string())
     }
 
     #[getter]
@@ -658,8 +630,8 @@ impl Category {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("name", &self.name)?;
-        dict.set_item("category_type", &self.category_type)?;
+        dict.set_item("name", &*self.name)?;
+        dict.set_item("category_type", &*self.category_type)?;
         dict.set_item("highest_index", self.highest_index)?;
 
         let mut field_dicts = Vec::new();
@@ -740,21 +712,21 @@ pub struct State {
     #[serde(rename = "value")]
     #[serde(alias = "@value")]
     #[serde(alias = "value")]
-    pub value: String,
+    pub value: Arc<str>,
     #[serde(rename = "signer")]
     #[serde(alias = "@signer")]
     #[serde(alias = "signer")]
-    pub signer: String,
+    pub signer: Arc<str>,
     #[serde(rename = "signerUniqueId")]
     #[serde(alias = "@signerUniqueId")]
     #[serde(alias = "signerUniqueId")]
-    pub signer_unique_id: String,
+    pub signer_unique_id: Arc<str>,
 
     #[serde(rename = "dateSigned")]
     #[serde(alias = "@dateSigned")]
     #[serde(alias = "dateSigned")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_signed: Option<DateTime<Utc>>,
@@ -767,21 +739,21 @@ pub struct State {
     #[serde(rename = "value")]
     #[serde(alias = "@value")]
     #[serde(alias = "value")]
-    pub value: String,
+    pub value: Arc<str>,
     #[serde(rename = "signer")]
     #[serde(alias = "@signer")]
     #[serde(alias = "signer")]
-    pub signer: String,
+    pub signer: Arc<str>,
     #[serde(rename = "signerUniqueId")]
     #[serde(alias = "@signerUniqueId")]
     #[serde(alias = "signerUniqueId")]
-    pub signer_unique_id: String,
+    pub signer_unique_id: Arc<str>,
 
     #[serde(rename = "dateSigned")]
     #[serde(alias = "@dateSigned")]
     #[serde(alias = "dateSigned")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_signed: Option<DateTime<Utc>>,
@@ -792,17 +764,17 @@ pub struct State {
 impl State {
     #[getter]
     fn value(&self) -> PyResult<String> {
-        Ok(self.value.clone())
+        Ok(self.value.to_string())
     }
 
     #[getter]
     fn signer(&self) -> PyResult<String> {
-        Ok(self.signer.clone())
+        Ok(self.signer.to_string())
     }
 
     #[getter]
     fn signer_unique_id(&self) -> PyResult<String> {
-        Ok(self.signer_unique_id.clone())
+        Ok(self.signer_unique_id.to_string())
     }
 
     #[getter]
@@ -812,9 +784,9 @@ impl State {
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item("value", &self.value)?;
-        dict.set_item("signer", &self.signer)?;
-        dict.set_item("signer_unique_id", &self.signer_unique_id)?;
+        dict.set_item("value", &*self.value)?;
+        dict.set_item("signer", &*self.signer)?;
+        dict.set_item("signer_unique_id", &*self.signer_unique_id)?;
         dict.set_item("date_signed", to_py_datetime_option(py, &self.date_signed)?)?;
 
         Ok(dict)
@@ -832,26 +804,20 @@ pub struct LockState {
     #[serde(rename = "user")]
     #[serde(alias = "@user")]
     #[serde(alias = "user")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user: Option<String>,
 
     #[serde(rename = "userUniqueId")]
     #[serde(alias = "@userUniqueId")]
     #[serde(alias = "userUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user_unique_id: Option<String>,
 
     #[serde(rename = "dateTimeChanged")]
     #[serde(alias = "@dateTimeChanged")]
     #[serde(alias = "dateTimeChanged")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_time_changed: Option<DateTime<Utc>>,
@@ -869,26 +835,20 @@ pub struct LockState {
     #[serde(rename = "user")]
     #[serde(alias = "@user")]
     #[serde(alias = "user")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user: Option<String>,
 
     #[serde(rename = "userUniqueId")]
     #[serde(alias = "@userUniqueId")]
     #[serde(alias = "userUniqueId")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user_unique_id: Option<String>,
 
     #[serde(rename = "dateTimeChanged")]
     #[serde(alias = "@dateTimeChanged")]
     #[serde(alias = "dateTimeChanged")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_time_changed: Option<DateTime<Utc>>,
@@ -943,7 +903,7 @@ pub struct Form {
     #[serde(alias = "@lastModified")]
     #[serde(alias = "lastModified")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub last_modified: Option<DateTime<Utc>>,
@@ -951,19 +911,13 @@ pub struct Form {
     #[serde(rename = "whoLastModifiedName")]
     #[serde(alias = "@whoLastModifiedName")]
     #[serde(alias = "whoLastModifiedName")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub who_last_modified_name: Option<String>,
 
     #[serde(rename = "whoLastModifiedRole")]
     #[serde(alias = "@whoLastModifiedRole")]
     #[serde(alias = "whoLastModifiedRole")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub who_last_modified_role: Option<String>,
 
     #[serde(rename = "whenCreated")]
@@ -986,17 +940,14 @@ pub struct Form {
     #[serde(rename = "user")]
     #[serde(alias = "@user")]
     #[serde(alias = "user")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user: Option<String>,
 
     #[serde(rename = "dateTimeChanged")]
     #[serde(alias = "@dateTimeChanged")]
     #[serde(alias = "dateTimeChanged")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_time_changed: Option<DateTime<Utc>>,
@@ -1013,10 +964,7 @@ pub struct Form {
     #[serde(rename = "formGroup")]
     #[serde(alias = "@formGroup")]
     #[serde(alias = "formGroup")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub form_group: Option<String>,
 
     #[serde(rename = "formState")]
@@ -1047,7 +995,7 @@ pub struct Form {
     #[serde(alias = "@lastModified")]
     #[serde(alias = "lastModified")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub last_modified: Option<DateTime<Utc>>,
@@ -1055,19 +1003,13 @@ pub struct Form {
     #[serde(rename = "whoLastModifiedName")]
     #[serde(alias = "@whoLastModifiedName")]
     #[serde(alias = "whoLastModifiedName")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub who_last_modified_name: Option<String>,
 
     #[serde(rename = "whoLastModifiedRole")]
     #[serde(alias = "@whoLastModifiedRole")]
     #[serde(alias = "whoLastModifiedRole")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub who_last_modified_role: Option<String>,
 
     #[serde(rename = "whenCreated")]
@@ -1090,17 +1032,14 @@ pub struct Form {
     #[serde(rename = "user")]
     #[serde(alias = "@user")]
     #[serde(alias = "user")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub user: Option<String>,
 
     #[serde(rename = "dateTimeChanged")]
     #[serde(alias = "@dateTimeChanged")]
     #[serde(alias = "dateTimeChanged")]
     #[serde(
-        default = "default_datetime_none",
+        default,
         deserialize_with = "deserialize_empty_string_as_none_datetime"
     )]
     pub date_time_changed: Option<DateTime<Utc>>,
@@ -1117,10 +1056,7 @@ pub struct Form {
     #[serde(rename = "formGroup")]
     #[serde(alias = "@formGroup")]
     #[serde(alias = "formGroup")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub form_group: Option<String>,
 
     #[serde(rename = "formState")]
@@ -1282,7 +1218,10 @@ impl Form {
 }
 
 impl State {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut value = "";
         let mut signer = "";
         let mut signer_unique_id = "";
@@ -1297,9 +1236,9 @@ impl State {
         })?;
 
         Ok(State {
-            value: value.to_string(),
-            signer: signer.to_string(),
-            signer_unique_id: signer_unique_id.to_string(),
+            value: interner.intern(value),
+            signer: interner.intern(signer),
+            signer_unique_id: interner.intern(signer_unique_id),
             date_signed: optional_datetime(date_signed),
         })
     }
@@ -1330,7 +1269,10 @@ impl LockState {
 }
 
 impl Category {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut name = "";
         let mut category_type = "";
         let mut highest_index = "";
@@ -1343,8 +1285,8 @@ impl Category {
         })?;
 
         Ok(Category {
-            name: name.to_string(),
-            category_type: category_type.to_string(),
+            name: interner.intern(name),
+            category_type: interner.intern(category_type),
             highest_index: highest_index.parse().unwrap_or(0),
             fields: None,
         })
@@ -1352,7 +1294,10 @@ impl Category {
 }
 
 impl Field {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut name = "";
         let mut field_type = "";
         let mut data_type = "";
@@ -1371,10 +1316,10 @@ impl Field {
         })?;
 
         Ok(Field {
-            name: name.to_string(),
-            field_type: field_type.to_string(),
-            data_type: optional_string(data_type),
-            error_code: error_code.to_string(),
+            name: interner.intern(name),
+            field_type: interner.intern(field_type),
+            data_type: interner.intern_optional(data_type),
+            error_code: interner.intern(error_code),
             when_created: checked_datetime(when_created)?,
             keep_history: keep_history == "true",
             entries: None,
@@ -1384,7 +1329,10 @@ impl Field {
 }
 
 impl Entry {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut id: Option<&str> = None;
         let mut entry_id: Option<&str> = None;
         let mut reviewed_by = "";
@@ -1401,7 +1349,7 @@ impl Entry {
         })?;
 
         Ok(Entry {
-            entry_id: id.or(entry_id).unwrap_or_default().to_string(),
+            entry_id: interner.intern(id.or(entry_id).unwrap_or_default()),
             reviewed_by: optional_string(reviewed_by),
             reviewed_by_unique_id: optional_string(reviewed_by_unique_id),
             reviewed_by_when: optional_datetime(reviewed_by_when),
@@ -1412,7 +1360,10 @@ impl Entry {
 }
 
 impl Value {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut by = "";
         let mut by_unique_id = "";
         let mut role = "";
@@ -1427,9 +1378,9 @@ impl Value {
         })?;
 
         Ok(Value {
-            by: by.to_string(),
-            by_unique_id: optional_string(by_unique_id),
-            role: role.to_string(),
+            by: interner.intern(by),
+            by_unique_id: interner.intern_optional(by_unique_id),
+            role: interner.intern(role),
             when: checked_datetime(when)?,
             value: String::new(),
         })
@@ -1437,7 +1388,10 @@ impl Value {
 }
 
 impl Reason {
-    pub(crate) fn from_attributes(e: &BytesStart<'_>) -> Result<Self, crate::errors::Error> {
+    pub(crate) fn from_attributes(
+        e: &BytesStart<'_>,
+        interner: &mut Interner,
+    ) -> Result<Self, crate::errors::Error> {
         let mut by = "";
         let mut by_unique_id = "";
         let mut role = "";
@@ -1452,9 +1406,9 @@ impl Reason {
         })?;
 
         Ok(Reason {
-            by: by.to_string(),
-            by_unique_id: optional_string(by_unique_id),
-            role: role.to_string(),
+            by: interner.intern(by),
+            by_unique_id: interner.intern_optional(by_unique_id),
+            role: interner.intern(role),
             when: checked_datetime(when)?,
             value: String::new(),
         })

--- a/crates/prelude-xml-parser/src/native/deserializers.rs
+++ b/crates/prelude-xml-parser/src/native/deserializers.rs
@@ -1,8 +1,7 @@
+use std::{borrow::Cow, collections::HashSet, str::from_utf8, sync::Arc};
+
 #[cfg(feature = "python")]
 use chrono::{Datelike, Timelike};
-
-use std::borrow::Cow;
-use std::str::from_utf8;
 
 use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone, Utc};
 
@@ -11,6 +10,38 @@ use quick_xml::{
     events::{BytesRef, BytesStart},
 };
 use serde::{Deserialize, Deserializer};
+
+/// Deduplicates the heavily repeated attribute values within a single record.
+///
+/// Values such as a field's `type`, `dataType` and `errorCode` take only a handful of distinct
+/// values across hundreds of thousands of elements, so handing out a shared `Arc<str>` replaces
+/// one allocation per occurrence with one per distinct value. One interner is used per parsed
+/// record so that no synchronisation is needed between threads.
+#[derive(Default)]
+pub(crate) struct Interner {
+    seen: HashSet<Arc<str>>,
+}
+
+impl Interner {
+    pub(crate) fn intern(&mut self, value: &str) -> Arc<str> {
+        if let Some(existing) = self.seen.get(value) {
+            return existing.clone();
+        }
+
+        let shared: Arc<str> = Arc::from(value);
+        self.seen.insert(shared.clone());
+
+        shared
+    }
+
+    pub(crate) fn intern_optional(&mut self, value: &str) -> Option<Arc<str>> {
+        if value.is_empty() {
+            None
+        } else {
+            Some(self.intern(value))
+        }
+    }
+}
 
 pub(crate) fn decode_error(e: impl std::fmt::Display) -> crate::errors::Error {
     crate::errors::Error::ParsingError(quick_xml::de::DeError::Custom(format!(
@@ -245,12 +276,18 @@ where
     }
 }
 
-pub fn default_datetime_none() -> Option<DateTime<Utc>> {
-    None
-}
-
-pub fn default_string_none() -> Option<String> {
-    None
+pub fn deserialize_empty_string_as_none_arc<'de, D>(
+    deserializer: D,
+) -> Result<Option<Arc<str>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = Option::<String>::deserialize(deserializer)?;
+    match s {
+        Some(v) if v.is_empty() => Ok(None),
+        Some(v) => Ok(Some(Arc::from(v.as_str()))),
+        None => Ok(None),
+    }
 }
 
 #[cfg(feature = "python")]

--- a/crates/prelude-xml-parser/src/native/subject_native.rs
+++ b/crates/prelude-xml-parser/src/native/subject_native.rs
@@ -14,9 +14,7 @@ use crate::native::deserializers::{
 };
 
 #[cfg(feature = "python")]
-use crate::native::deserializers::{
-    default_string_none, deserialize_empty_string_as_none, to_py_datetime,
-};
+use crate::native::deserializers::{deserialize_empty_string_as_none, to_py_datetime};
 
 use serde::{Deserialize, Serialize};
 
@@ -117,10 +115,7 @@ pub struct Patient {
     #[serde(rename = "lastLanguage")]
     #[serde(alias = "@lastLanguage")]
     #[serde(alias = "lastLanguage")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub last_language: Option<String>,
 
     #[serde(rename = "numberOfForms")]

--- a/crates/prelude-xml-parser/src/native/user_native.rs
+++ b/crates/prelude-xml-parser/src/native/user_native.rs
@@ -7,8 +7,7 @@ pub use crate::native::common::{Category, Comment, Entry, Field, Form, Reason, S
 use quick_xml::events::BytesStart;
 
 use crate::native::deserializers::{
-    default_string_none, deserialize_empty_string_as_none, optional_string, required_attribute,
-    visit_attributes,
+    deserialize_empty_string_as_none, optional_string, required_attribute, visit_attributes,
 };
 
 #[cfg(not(feature = "python"))]
@@ -23,10 +22,7 @@ pub struct User {
     #[serde(rename = "lastLanguage")]
     #[serde(alias = "@lastLanguage")]
     #[serde(alias = "lastLanguage")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub last_language: Option<String>,
     #[serde(rename = "creator")]
     #[serde(alias = "@creator")]
@@ -84,10 +80,7 @@ pub struct User {
     #[serde(rename = "lastLanguage")]
     #[serde(alias = "@lastLanguage")]
     #[serde(alias = "lastLanguage")]
-    #[serde(
-        default = "default_string_none",
-        deserialize_with = "deserialize_empty_string_as_none"
-    )]
+    #[serde(default, deserialize_with = "deserialize_empty_string_as_none")]
     pub last_language: Option<String>,
     #[serde(rename = "creator")]
     #[serde(alias = "@creator")]


### PR DESCRIPTION
Breaking Change: Field, Value, Reason, Category, Entry, State now expose Arc<str> instead of String on the interned fields. Rust consumers comparing to string literals need &*x.name; constructing them needs .into() instead of .to_string(). Python consumers see no difference — getters still return str, and JSON output is byte-identical. Category also lost a redundant #[pyclass(get_all)] that duplicated its explicit getters.