### PR TITLE
Wrap field creation in Arc<Vec<T>> to improve performance

### DIFF
--- a/crates/prelude-xml-parser/src/lib.rs
+++ b/crates/prelude-xml-parser/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod errors;
 pub mod native;
 
-use std::{fs::read_to_string, path::Path};
+use std::{fs::read_to_string, path::Path, sync::Arc};
 
 use rayon::prelude::*;
 
@@ -144,7 +144,7 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                             .unwrap()
 ///                             .with_timezone(&Utc),
 ///                     ),
-///                 }]),
+///                 }].into()),
 ///                 categories: Some(vec![
 ///                     Category {
 ///                         name: "Demographics".into(),
@@ -193,7 +193,7 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                         value: "Some Company".into(),
 ///                                     }),
 ///                                     reason: None,
-///                                 }]),
+///                                 }].into()),
 ///                                 comments: None,
 ///                             },
 ///                             Field {
@@ -264,10 +264,10 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                             value: "calculated value".into(),
 ///                                         }),
 ///                                     },
-///                                 ]),
+///                                 ].into()),
 ///                                 comments: None,
 ///                             },
-///                         ]),
+///                         ].into()),
 ///                     },
 ///                     Category {
 ///                         name: "Enrollment".into(),
@@ -316,7 +316,7 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                         value: "Yes".into(),
 ///                                     }),
 ///                                     reason: None,
-///                                 }]),
+///                                 }].into()),
 ///                                 comments: None,
 ///                             },
 ///                             Field {
@@ -333,10 +333,10 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 entries: None,
 ///                                 comments: None,
 ///                             },
-///                         ]),
+///                         ].into()),
 ///                     },
-///                 ]),
-///             }]),
+///                 ].into()),
+///             }].into()),
 ///         },
 ///         Site {
 ///             name: "Artemis".into(),
@@ -377,7 +377,7 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                             .unwrap()
 ///                             .with_timezone(&Utc),
 ///                     ),
-///                 }]),
+///                 }].into()),
 ///                 categories: Some(vec![Category {
 ///                     name: "Demographics".into(),
 ///                     category_type: "normal".into(),
@@ -406,7 +406,7 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                 value: "1111 Moon Drive".into(),
 ///                             }),
 ///                             reason: None,
-///                         }]),
+///                         }].into()),
 ///                         comments: Some(vec![Comment {
 ///                             comment_id: "1".into(),
 ///                             value: Some(Value {
@@ -418,10 +418,10 @@ pub fn parse_site_native_file(xml_path: &Path) -> Result<SiteNative, Error> {
 ///                                     .with_timezone(&Utc)),
 ///                                 value: "Some comment".into(),
 ///                             }),
-///                         }]),
-///                     }]),
-///                 }]),
-///             }]),
+///                         }].into()),
+///                     }].into()),
+///                 }].into()),
+///             }].into()),
 ///         },
 ///     ],
 /// };
@@ -540,7 +540,7 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                             .unwrap()
 ///                             .with_timezone(&Utc),
 ///                     ),
-///                 }]),
+///                 }].into()),
 ///                 categories: Some(vec![Category {
 ///                     name: "Demographics".into(),
 ///                     category_type: "normal".into(),
@@ -569,11 +569,11 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                                 value: "Labrador".into(),
 ///                             }),
 ///                             reason: None,
-///                         }]),
+///                         }].into()),
 ///                         comments: None,
-///                     }]),
-///                 }]),
-///             }]),
+///                     }].into()),
+///                 }].into()),
+///             }].into()),
 ///         },
 ///         Patient {
 ///             patient_id: "DEF-002".into(),
@@ -613,7 +613,7 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                             .unwrap()
 ///                             .with_timezone(&Utc),
 ///                     ),
-///                 }]),
+///                 }].into()),
 ///                 categories: Some(vec![Category {
 ///                     name: "Demographics".into(),
 ///                     category_type: "normal".into(),
@@ -642,11 +642,11 @@ pub fn parse_subject_native_file(xml_path: &Path) -> Result<SubjectNative, Error
 ///                                 value: "Labrador".into(),
 ///                             }),
 ///                             reason: None,
-///                         }]),
+///                         }].into()),
 ///                         comments: None,
-///                     }]),
-///                 }]),
-///             }]),
+///                     }].into()),
+///                 }].into()),
+///             }].into()),
 ///         },
 ///     ],
 /// };
@@ -794,10 +794,12 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                         "form" if in_form => {
                             if let Some(mut form) = current_form.take() {
                                 if !current_states.is_empty() {
-                                    form.states = Some(current_states.drain(..).collect());
+                                    form.states =
+                                        Some(Arc::new(current_states.drain(..).collect()));
                                 }
                                 if !current_categories.is_empty() {
-                                    form.categories = Some(current_categories.drain(..).collect());
+                                    form.categories =
+                                        Some(Arc::new(current_categories.drain(..).collect()));
                                 }
                                 current_forms.push(form);
                             }
@@ -806,7 +808,8 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                         "category" if in_category => {
                             if let Some(mut category) = current_category.take() {
                                 if !current_fields.is_empty() {
-                                    category.fields = Some(current_fields.drain(..).collect());
+                                    category.fields =
+                                        Some(Arc::new(current_fields.drain(..).collect()));
                                 }
                                 current_categories.push(category);
                             }
@@ -815,10 +818,12 @@ fn parse_patient_xml(patient_xml: &str) -> Result<Patient, Error> {
                         "field" if in_field => {
                             if let Some(mut field) = current_field.take() {
                                 if !current_entries.is_empty() {
-                                    field.entries = Some(current_entries.drain(..).collect());
+                                    field.entries =
+                                        Some(Arc::new(current_entries.drain(..).collect()));
                                 }
                                 if !current_comments.is_empty() {
-                                    field.comments = Some(current_comments.drain(..).collect());
+                                    field.comments =
+                                        Some(Arc::new(current_comments.drain(..).collect()));
                                 }
                                 current_fields.push(field);
                             }
@@ -1040,10 +1045,12 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                         "form" if in_form => {
                             if let Some(mut form) = current_form.take() {
                                 if !current_states.is_empty() {
-                                    form.states = Some(current_states.drain(..).collect());
+                                    form.states =
+                                        Some(Arc::new(current_states.drain(..).collect()));
                                 }
                                 if !current_categories.is_empty() {
-                                    form.categories = Some(current_categories.drain(..).collect());
+                                    form.categories =
+                                        Some(Arc::new(current_categories.drain(..).collect()));
                                 }
                                 current_forms.push(form);
                             }
@@ -1052,7 +1059,8 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                         "category" if in_category => {
                             if let Some(mut category) = current_category.take() {
                                 if !current_fields.is_empty() {
-                                    category.fields = Some(current_fields.drain(..).collect());
+                                    category.fields =
+                                        Some(Arc::new(current_fields.drain(..).collect()));
                                 }
                                 current_categories.push(category);
                             }
@@ -1061,10 +1069,12 @@ fn parse_site_xml(site_xml: &str) -> Result<Site, Error> {
                         "field" if in_field => {
                             if let Some(mut field) = current_field.take() {
                                 if !current_entries.is_empty() {
-                                    field.entries = Some(current_entries.drain(..).collect());
+                                    field.entries =
+                                        Some(Arc::new(current_entries.drain(..).collect()));
                                 }
                                 if !current_comments.is_empty() {
-                                    field.comments = Some(current_comments.drain(..).collect());
+                                    field.comments =
+                                        Some(Arc::new(current_comments.drain(..).collect()));
                                 }
                                 current_fields.push(field);
                             }
@@ -1249,7 +1259,7 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///                         .unwrap()
 ///                         .with_timezone(&Utc),
 ///                 ),
-///             }]),
+///             }].into()),
 ///             categories: Some(vec![
 ///                         Category {
 ///                             name: "demographics".into(),
@@ -1292,10 +1302,10 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///                                             value: "jazz@artemis.com".into(),
 ///                                         }),
 ///                                         reason: None,
-///                                     }]),
+///                                     }].into()),
 ///                                     comments: None,
 ///                                 },
-///                             ]),
+///                             ].into()),
 ///                         },
 ///                         Category {
 ///                             name: "Administrative".into(),
@@ -1336,13 +1346,13 @@ pub fn parse_user_native_file(xml_path: &Path) -> Result<UserNative, Error> {
 ///                                                 value: "calculated value".into(),
 ///                                             }),
 ///                                         },
-///                                     ]),
+///                                     ].into()),
 ///                                     comments: None,
 ///                                 },
-///                             ]),
+///                             ].into()),
 ///                         },
-///             ]),
-///         }]),
+///             ].into()),
+///         }].into()),
 ///     }],
 /// };
 ///
@@ -1484,10 +1494,12 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                         "form" if in_form => {
                             if let Some(mut form) = current_form.take() {
                                 if !current_states.is_empty() {
-                                    form.states = Some(current_states.drain(..).collect());
+                                    form.states =
+                                        Some(Arc::new(current_states.drain(..).collect()));
                                 }
                                 if !current_categories.is_empty() {
-                                    form.categories = Some(current_categories.drain(..).collect());
+                                    form.categories =
+                                        Some(Arc::new(current_categories.drain(..).collect()));
                                 }
                                 current_forms.push(form);
                             }
@@ -1496,7 +1508,8 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                         "category" if in_category => {
                             if let Some(mut category) = current_category.take() {
                                 if !current_fields.is_empty() {
-                                    category.fields = Some(current_fields.drain(..).collect());
+                                    category.fields =
+                                        Some(Arc::new(current_fields.drain(..).collect()));
                                 }
                                 current_categories.push(category);
                             }
@@ -1505,10 +1518,12 @@ fn parse_user_xml(user_xml: &str) -> Result<User, Error> {
                         "field" if in_field => {
                             if let Some(mut field) = current_field.take() {
                                 if !current_entries.is_empty() {
-                                    field.entries = Some(current_entries.drain(..).collect());
+                                    field.entries =
+                                        Some(Arc::new(current_entries.drain(..).collect()));
                                 }
                                 if !current_comments.is_empty() {
-                                    field.comments = Some(current_comments.drain(..).collect());
+                                    field.comments =
+                                        Some(Arc::new(current_comments.drain(..).collect()));
                                 }
                                 current_fields.push(field);
                             }

--- a/crates/prelude-xml-parser/src/native/common.rs
+++ b/crates/prelude-xml-parser/src/native/common.rs
@@ -427,10 +427,10 @@ pub struct Field {
     pub keep_history: bool,
 
     #[serde(alias = "entry")]
-    pub entries: Option<Vec<Entry>>,
+    pub entries: Option<Arc<Vec<Entry>>>,
 
     #[serde(alias = "comment")]
-    pub comments: Option<Vec<Comment>>,
+    pub comments: Option<Arc<Vec<Comment>>>,
 }
 
 #[cfg(feature = "python")]
@@ -467,10 +467,10 @@ pub struct Field {
     pub keep_history: bool,
 
     #[serde(alias = "entry")]
-    pub entries: Option<Vec<Entry>>,
+    pub entries: Option<Arc<Vec<Entry>>>,
 
     #[serde(alias = "comment")]
-    pub comments: Option<Vec<Comment>>,
+    pub comments: Option<Arc<Vec<Comment>>>,
 }
 
 #[cfg(feature = "python")]
@@ -511,12 +511,12 @@ impl Field {
 
     #[getter]
     fn entries(&self) -> PyResult<Option<Vec<Entry>>> {
-        Ok(self.entries.clone())
+        Ok(self.entries.as_deref().cloned())
     }
 
     #[getter]
     fn comments(&self) -> PyResult<Option<Vec<Comment>>> {
-        Ok(self.comments.clone())
+        Ok(self.comments.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -536,7 +536,7 @@ impl Field {
 
         let mut entry_dicts = Vec::new();
         if let Some(entries) = &self.entries {
-            for entry in entries {
+            for entry in entries.iter() {
                 let entry_dict = entry.to_dict(py)?;
                 entry_dicts.push(entry_dict);
             }
@@ -547,7 +547,7 @@ impl Field {
 
         let mut comment_dicts = Vec::new();
         if let Some(comments) = &self.comments {
-            for comment in comments {
+            for comment in comments.iter() {
                 let comment_dict = comment.to_dict(py)?;
                 comment_dicts.push(comment_dict);
             }
@@ -579,7 +579,7 @@ pub struct Category {
     pub highest_index: usize,
 
     #[serde(alias = "field")]
-    pub fields: Option<Vec<Field>>,
+    pub fields: Option<Arc<Vec<Field>>>,
 }
 
 #[cfg(feature = "python")]
@@ -602,7 +602,7 @@ pub struct Category {
     pub highest_index: usize,
 
     #[serde(alias = "field")]
-    pub fields: Option<Vec<Field>>,
+    pub fields: Option<Arc<Vec<Field>>>,
 }
 
 #[cfg(feature = "python")]
@@ -625,7 +625,7 @@ impl Category {
 
     #[getter]
     fn fields(&self) -> PyResult<Option<Vec<Field>>> {
-        Ok(self.fields.clone())
+        Ok(self.fields.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -636,7 +636,7 @@ impl Category {
 
         let mut field_dicts = Vec::new();
         if let Some(fields) = &self.fields {
-            for field in fields {
+            for field in fields.iter() {
                 let field_dict = field.to_dict(py)?;
                 field_dicts.push(field_dict);
             }
@@ -973,13 +973,13 @@ pub struct Form {
     pub form_state: String,
 
     #[serde(alias = "state")]
-    pub states: Option<Vec<State>>,
+    pub states: Option<Arc<Vec<State>>>,
 
     #[serde(alias = "lockState")]
     pub lock_state: Option<LockState>,
 
     #[serde(alias = "category")]
-    pub categories: Option<Vec<Category>>,
+    pub categories: Option<Arc<Vec<Category>>>,
 }
 
 #[cfg(feature = "python")]
@@ -1065,13 +1065,13 @@ pub struct Form {
     pub form_state: String,
 
     #[serde(alias = "state")]
-    pub states: Option<Vec<State>>,
+    pub states: Option<Arc<Vec<State>>>,
 
     #[serde(alias = "lockState")]
     pub lock_state: Option<LockState>,
 
     #[serde(alias = "category")]
-    pub categories: Option<Vec<Category>>,
+    pub categories: Option<Arc<Vec<Category>>>,
 }
 
 #[cfg(feature = "python")]
@@ -1149,7 +1149,7 @@ impl Form {
 
     #[getter]
     fn states(&self) -> PyResult<Option<Vec<State>>> {
-        Ok(self.states.clone())
+        Ok(self.states.as_deref().cloned())
     }
 
     #[getter]
@@ -1159,7 +1159,7 @@ impl Form {
 
     #[getter]
     fn categories(&self) -> PyResult<Option<Vec<Category>>> {
-        Ok(self.categories.clone())
+        Ok(self.categories.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -1187,7 +1187,7 @@ impl Form {
 
         let mut state_dicts = Vec::new();
         if let Some(states) = &self.states {
-            for state in states {
+            for state in states.iter() {
                 let state_dict = state.to_dict(py)?;
                 state_dicts.push(state_dict);
             }
@@ -1204,7 +1204,7 @@ impl Form {
 
         if let Some(categories) = &self.categories {
             let mut category_dicts = Vec::new();
-            for category in categories {
+            for category in categories.iter() {
                 let category_dict = category.to_dict(py)?;
                 category_dicts.push(category_dict);
             }

--- a/crates/prelude-xml-parser/src/native/deserializers.rs
+++ b/crates/prelude-xml-parser/src/native/deserializers.rs
@@ -5,6 +5,9 @@ use chrono::{Datelike, Timelike};
 
 use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone, Utc};
 
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDateTime};
+
 use quick_xml::{
     escape::resolve_predefined_entity,
     events::{BytesRef, BytesStart},
@@ -233,9 +236,6 @@ pub(crate) fn parse_datetime(s: &str) -> Result<DateTime<Utc>, crate::errors::Er
         ))
     }
 }
-
-#[cfg(feature = "python")]
-use pyo3::{prelude::*, types::PyDateTime};
 
 pub fn deserialize_empty_string_as_none_datetime<'de, D>(
     deserializer: D,

--- a/crates/prelude-xml-parser/src/native/site_native.rs
+++ b/crates/prelude-xml-parser/src/native/site_native.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "python")]
@@ -51,7 +53,7 @@ pub struct Site {
 
     #[serde(rename = "form")]
     #[serde(alias = "form")]
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 #[cfg(not(feature = "python"))]
@@ -89,7 +91,11 @@ impl Site {
     }
 
     pub(crate) fn set_forms(&mut self, forms: Vec<Form>) {
-        self.forms = if forms.is_empty() { None } else { Some(forms) };
+        self.forms = if forms.is_empty() {
+            None
+        } else {
+            Some(Arc::new(forms))
+        };
     }
 }
 
@@ -127,7 +133,7 @@ pub struct Site {
 
     #[serde(rename = "form")]
     #[serde(alias = "form")]
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 #[cfg(feature = "python")]
@@ -165,7 +171,11 @@ impl Site {
     }
 
     pub(crate) fn set_forms(&mut self, forms: Vec<Form>) {
-        self.forms = if forms.is_empty() { None } else { Some(forms) };
+        self.forms = if forms.is_empty() {
+            None
+        } else {
+            Some(Arc::new(forms))
+        };
     }
 }
 
@@ -212,7 +222,7 @@ impl Site {
 
     #[getter]
     fn forms(&self) -> PyResult<Option<Vec<Form>>> {
-        Ok(self.forms.clone())
+        Ok(self.forms.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -236,7 +246,7 @@ impl Site {
 
         let mut form_dicts = Vec::new();
         if let Some(forms) = &self.forms {
-            for form in forms {
+            for form in forms.iter() {
                 let form_dict = form.to_dict(py)?;
                 form_dicts.push(form_dict);
             }

--- a/crates/prelude-xml-parser/src/native/subject_native.rs
+++ b/crates/prelude-xml-parser/src/native/subject_native.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "python")]
@@ -38,7 +40,7 @@ pub struct Patient {
     pub last_language: Option<String>,
     #[serde(rename = "numberOfForms")]
     pub number_of_forms: usize,
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 impl Patient {
@@ -78,7 +80,11 @@ impl Patient {
     }
 
     pub(crate) fn set_forms(&mut self, forms: Vec<Form>) {
-        self.forms = if forms.is_empty() { None } else { Some(forms) };
+        self.forms = if forms.is_empty() {
+            None
+        } else {
+            Some(Arc::new(forms))
+        };
     }
 }
 
@@ -124,7 +130,7 @@ pub struct Patient {
     pub number_of_forms: usize,
 
     #[serde(alias = "form")]
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 #[cfg(feature = "python")]
@@ -175,7 +181,7 @@ impl Patient {
 
     #[getter]
     fn forms(&self) -> PyResult<Option<Vec<Form>>> {
-        Ok(self.forms.clone())
+        Ok(self.forms.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -197,7 +203,7 @@ impl Patient {
 
         let mut form_dicts = Vec::new();
         if let Some(forms) = &self.forms {
-            for form in forms {
+            for form in forms.iter() {
                 let form_dict = form.to_dict(py)?;
                 form_dicts.push(form_dict);
             }

--- a/crates/prelude-xml-parser/src/native/user_native.rs
+++ b/crates/prelude-xml-parser/src/native/user_native.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "python")]
@@ -34,7 +36,7 @@ pub struct User {
     pub number_of_forms: usize,
 
     #[serde(alias = "form")]
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 #[cfg(not(feature = "python"))]
@@ -63,14 +65,18 @@ impl User {
     }
 
     pub(crate) fn set_forms(&mut self, forms: Vec<Form>) {
-        self.forms = if forms.is_empty() { None } else { Some(forms) };
+        self.forms = if forms.is_empty() {
+            None
+        } else {
+            Some(Arc::new(forms))
+        };
     }
 }
 
 #[cfg(feature = "python")]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(get_all, skip_from_py_object)]
+#[pyclass(skip_from_py_object)]
 pub struct User {
     #[serde(rename = "uniqueId")]
     #[serde(alias = "@uniqueId")]
@@ -92,7 +98,7 @@ pub struct User {
     pub number_of_forms: usize,
 
     #[serde(alias = "form")]
-    pub forms: Option<Vec<Form>>,
+    pub forms: Option<Arc<Vec<Form>>>,
 }
 
 #[cfg(feature = "python")]
@@ -121,7 +127,11 @@ impl User {
     }
 
     pub(crate) fn set_forms(&mut self, forms: Vec<Form>) {
-        self.forms = if forms.is_empty() { None } else { Some(forms) };
+        self.forms = if forms.is_empty() {
+            None
+        } else {
+            Some(Arc::new(forms))
+        };
     }
 }
 
@@ -144,8 +154,13 @@ impl User {
     }
 
     #[getter]
+    fn number_of_forms(&self) -> PyResult<usize> {
+        Ok(self.number_of_forms)
+    }
+
+    #[getter]
     fn forms(&self) -> PyResult<Option<Vec<Form>>> {
-        Ok(self.forms.clone())
+        Ok(self.forms.as_deref().cloned())
     }
 
     pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -157,7 +172,7 @@ impl User {
 
         let mut form_dicts = Vec::new();
         if let Some(forms) = &self.forms {
-            for form in forms {
+            for form in forms.iter() {
                 let form_dict = form.to_dict(py)?;
                 form_dicts.push(form_dict);
             }


### PR DESCRIPTION
Rust consumers now see Arc<Vec<T>> on child collections. Python consumers only see improved performance