### PR TITLE
Fix incorrectly named function

### DIFF
--- a/crates/prelude-xml-parser/src/native/subject_native.rs
+++ b/crates/prelude-xml-parser/src/native/subject_native.rs
@@ -263,7 +263,7 @@ pub struct SubjectNative {
 #[pymethods]
 impl SubjectNative {
     #[getter]
-    fn sites(&self) -> PyResult<Vec<Patient>> {
+    fn patients(&self) -> PyResult<Vec<Patient>> {
         Ok(self.patients.clone())
     }
 


### PR DESCRIPTION
The SubjectNative struct had a getter called sites that returns the patient. It was renamed to patients for correctness